### PR TITLE
Trigger reconciliation of owner if change in controlled resource is detected

### DIFF
--- a/api/v1/prefixclaim_types.go
+++ b/api/v1/prefixclaim_types.go
@@ -17,9 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	"strings"
-
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -91,48 +88,6 @@ type PrefixClaimList struct {
 
 func init() {
 	SchemeBuilder.Register(&PrefixClaim{}, &PrefixClaimList{})
-}
-
-func (r *PrefixClaim) GeneratePrefixSpec(prefix string) PrefixSpec {
-	return PrefixSpec{
-		Prefix:      prefix,
-		Site:        r.Spec.Site,
-		Tenant:      r.Spec.Tenant,
-		Description: r.Spec.Description,
-		Comments:    r.Spec.Comments,
-	}
-}
-
-func (r *PrefixClaim) GeneratePrefix(prefix string) *Prefix {
-	prefixResource := &Prefix{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Prefix",
-			APIVersion: "netbox.dev/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.GetPrefixName(),
-			Namespace: r.ObjectMeta.Namespace,
-		},
-		Spec: r.GeneratePrefixSpec(prefix),
-	}
-	owner := []metav1.OwnerReference{
-		{
-			APIVersion: r.APIVersion,
-			Kind:       r.Kind,
-			Name:       r.Name,
-			UID:        r.UID,
-		},
-	}
-	prefixResource.SetOwnerReferences(owner)
-	return prefixResource
-}
-
-func (r *PrefixClaim) GetPrefixName() string {
-	if len(r.ObjectMeta.UID) == 0 {
-		panic(errors.New("UUID not provided in PrefixClaim resource"))
-	}
-	splitted_uid := strings.Split(string(r.ObjectMeta.UID), "-")
-	return r.ObjectMeta.Name + "-" + splitted_uid[0]
 }
 
 var ConditionPrefixClaimReadyTrue = metav1.Condition{

--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -148,7 +148,7 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// 6.a create the IPAddress object
 		ipAddressResource := generateIpAddressFromIpAddressClaim(o, ipAddressModel.IpAddress)
-		err = controllerutil.SetOwnerReference(o, ipAddressResource, r.Scheme)
+		err = controllerutil.SetControllerReference(o, ipAddressResource, r.Scheme)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/ipaddressclaim_controller_test.go
+++ b/internal/controller/ipaddressclaim_controller_test.go
@@ -135,11 +135,6 @@ var _ = Describe("IpAddressClaim Controller", Ordered, func() {
 
 			// check that the ip address claim controller created the ip address CR with correct spec
 			Expect(createdIpCR.Spec).To(Equal(ipcr.Spec))
-
-			// Change status of claim to trigger reconciliation (watch on ip address doesn't cause automatic reconciliation with env test)
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetName(), Namespace: cr.GetNamespace()}, createdCR)).To(Succeed())
-			apismeta.SetStatusCondition(&cr.Status.Conditions, netboxv1.ConditionIpClaimReadyFalse)
-			Expect(k8sClient.Status().Update(ctx, createdCR)).To(Succeed())
 		}
 
 		// Now check if conditions are set as expected

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -147,7 +147,7 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		/* 6-1, create the Prefix object */
 		prefixResource := generatePrefixFromPrefixClaim(prefixClaim, prefixModel.Prefix)
-		err = controllerutil.SetOwnerReference(prefixClaim, prefixResource, r.Scheme)
+		err = controllerutil.SetControllerReference(prefixClaim, prefixResource, r.Scheme)
 		if err != nil {
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
Before this change the reconciliation of a claim resource wasn't triggered if a change was detected in the owned resource because of the missing controller reference in the owner reference

Changes:
Use an owner reference with a reference to a controller
Remove status update which is no longer needed in ip address claim controller test
Remove unused functions from prefix claim type