### PR TITLE
Move the warning for ignored manually defined restoration hash to claim controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,6 @@ docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
 
 .PHONY: docker-build-local
-docker-build-local: SSH_AGENT_PUBLIC_KEY=
 docker-build-local: ## Build docker image with the manager.
 	DOCKER_BUILDKIT=1 $(CONTAINER_TOOL) build -t ${LOCAL_IMG} -f Dockerfile .
 

--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -142,11 +142,6 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// 2. reserve or update ip address in netbox
-	_, ok := o.Spec.CustomFields[config.GetOperatorConfig().NetboxRestorationHashFieldName]
-	if ok {
-		logger.Info(fmt.Sprintf("Warning: restoration hash is calculated from spec, custom field with key %s will be ignored", config.GetOperatorConfig().NetboxRestorationHashFieldName))
-	}
-
 	accessor := apismeta.NewAccessor()
 	annotations, err := accessor.Annotations(o)
 	if err != nil {

--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -147,7 +147,7 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 
 		// 6.a create the IPAddress object
-		ipAddressResource := generateIpAddressFromIpAddressClaim(o, ipAddressModel.IpAddress)
+		ipAddressResource := generateIpAddressFromIpAddressClaim(o, ipAddressModel.IpAddress, logger)
 		err = controllerutil.SetControllerReference(o, ipAddressResource, r.Scheme)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -175,7 +175,7 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, err
 		}
 
-		updatedIpAddressSpec := generateIpAddressSpec(o, ipAddress.Spec.IpAddress)
+		updatedIpAddressSpec := generateIpAddressSpec(o, ipAddress.Spec.IpAddress, logger)
 		_, err = ctrl.CreateOrUpdate(ctx, r.Client, ipAddress, func() error {
 			// only add the mutable fields here
 			ipAddress.Spec.CustomFields = updatedIpAddressSpec.CustomFields

--- a/internal/controller/prefix_controller.go
+++ b/internal/controller/prefix_controller.go
@@ -142,11 +142,6 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	/* 2. reserve or update Prefix in netbox */
-	_, ok := prefix.Spec.CustomFields[config.GetOperatorConfig().NetboxRestorationHashFieldName]
-	if ok {
-		logger.Info(fmt.Sprintf("Warning: restoration hash is calculated from spec, custom field with key %s will be ignored", config.GetOperatorConfig().NetboxRestorationHashFieldName))
-	}
-
 	accessor := apismeta.NewAccessor()
 	annotations, err := accessor.Annotations(prefix)
 	if err != nil {

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -146,7 +146,7 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		/* 6-1, create the Prefix object */
-		prefixResource := generatePrefixFromPrefixClaim(prefixClaim, prefixModel.Prefix)
+		prefixResource := generatePrefixFromPrefixClaim(prefixClaim, prefixModel.Prefix, logger)
 		err = controllerutil.SetControllerReference(prefixClaim, prefixResource, r.Scheme)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -169,7 +169,7 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 
-		updatedPrefixSpec := generatePrefixSpec(prefixClaim, prefix.Spec.Prefix)
+		updatedPrefixSpec := generatePrefixSpec(prefixClaim, prefix.Spec.Prefix, logger)
 		if _, err = ctrl.CreateOrUpdate(ctx, r.Client, prefix, func() error {
 			// only add the mutable fields here
 			prefix.Spec.Site = updatedPrefixSpec.Site


### PR DESCRIPTION
- move the warning for ignored manually defined restoration hash to claim controller