### PR TITLE
Fix the url in .status.url for both IpAddress and Prefix CRs

### DIFF
--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -211,7 +211,7 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// 4. update status conditions
 	o.Status.IpAddressId = netboxIpAddressModel.ID
-	o.Status.IpAddressUrl = "https://" + config.GetOperatorConfig().NetboxHost + "/ipam/ip-addresses/" + strconv.FormatInt(netboxIpAddressModel.ID, 10)
+	o.Status.IpAddressUrl = config.GetBaseUrl() + "/ipam/ip-addresses/" + strconv.FormatInt(netboxIpAddressModel.ID, 10)
 	err = r.SetConditionAndCreateEvent(ctx, o, netboxv1.ConditionIpaddressReadyTrue, corev1.EventTypeNormal, "")
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/prefix_controller.go
+++ b/internal/controller/prefix_controller.go
@@ -206,7 +206,7 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	/* 4. update status conditions */
 	prefix.Status.PrefixId = netboxPrefixModel.ID
-	prefix.Status.PrefixUrl = "https://" + config.GetOperatorConfig().NetboxHost + "/ipam/prefixes/" + strconv.FormatInt(netboxPrefixModel.ID, 10)
+	prefix.Status.PrefixUrl = config.GetBaseUrl() + "/ipam/prefixes/" + strconv.FormatInt(netboxPrefixModel.ID, 10)
 	if err = r.SetConditionAndCreateEvent(ctx, prefix, netboxv1.ConditionPrefixReadyTrue, corev1.EventTypeNormal, ""); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,3 +92,15 @@ func GetOperatorConfig() *OperatorConfig {
 
 	return configuration
 }
+
+func GetProtocol() string {
+	if GetOperatorConfig().HttpsEnable {
+		return "https"
+	} else {
+		return "http"
+	}
+}
+
+func GetBaseUrl() string {
+	return GetProtocol() + "://" + GetOperatorConfig().NetboxHost
+}


### PR DESCRIPTION
Fixes #44

If HTTPS_ENABLE is set to false, .status.url now shows a correct http url