### PR TITLE
Generate docker images for tagged commits

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -35,14 +35,17 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}        
           tags: |
-            # for commits on the main branch only, we will generate the tag named `latest`
+            # (for commits on the main branch only) generate a tag named `latest`
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            # the tag named sha-[short sha value] will be generated in all cases
+            # (for all commits) generate a tag named sha-[short sha value]
             type=sha,enable=true
+            # (for tagged commits only) generate a tag identical to the git tag string, including the leading v
+            type=semver,pattern={{raw}},enable=${{startsWith(github.ref, 'refs/tags/v')}}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.ref == format('refs/heads/{0}', 'main') }}
+          # we push only if the pipeline is run against the commits on main branch or a tag
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Added the capability for the CI pipeline to generate docker images with git tags.

For example, if we tag a commit with `v0.0.1-alpha.1`, the docker images with the tag `v0.0.1-alpha.1` will be generated. 

You can see the effect here https://github.com/henrybear327/netbox-operator/pkgs/container/netbox-operator

Closes https://github.com/netbox-community/netbox-operator/issues/67