### PR TITLE
Update the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -50,8 +50,8 @@ body:
     id: config
     attributes:
       label: Netbox operator configuration (command line flags or environment variables)
-      value: |
-        # paste your configuration here
+      description: Please copy and paste your configuration here.
+      render: Shell
 
   - type: textarea
     id: logs


### PR DESCRIPTION
The default value of `# paste your configuration here` setting will make the rendered markdown ugly. 

Aligning it with `Relevant log output`
