### PR TITLE
Generate docker images with and without prefixed v for tagged commits

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -39,8 +39,9 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             # (for all commits) generate a tag named sha-[short sha value]
             type=sha,enable=true
-            # (for tagged commits only) generate a tag identical to the git tag string, including the leading v
+            # (for tagged commits only) generate tags identical to the git tag version, with and without the leading v
             type=semver,pattern={{raw}},enable=${{startsWith(github.ref, 'refs/tags/v')}}
+            type=semver,pattern={{version}},enable=${{startsWith(github.ref, 'refs/tags/v')}}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
There are 2 flavors of the image version tags. 
- For example, Prometheus images contain `:v.` [in the image tag](https://hub.docker.com/layers/prom/prometheus/v2.35.0/images/sha256-4b86ad59abc67fa19a6e1618e936f3fd0f6ae13f49260da55a03eeca763a0fb5)
- Ubuntu images [don't](https://hub.docker.com/_/ubuntu), which conforms to the [semver description](https://semver.org/#is-v123-a-semantic-version)

We will publish both for now and see how the usage turns out.