### PR TITLE
Add age column and fix column order

### DIFF
--- a/api/v1/ipaddress_types.go
+++ b/api/v1/ipaddress_types.go
@@ -63,6 +63,7 @@ type IpAddressStatus struct {
 //+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 //+kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.id`
 //+kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:resource:shortName=ip
 
 // IpAddress is the Schema for the ipaddresses API

--- a/api/v1/ipaddressclaim_types.go
+++ b/api/v1/ipaddressclaim_types.go
@@ -63,8 +63,9 @@ type IpAddressClaimStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion
 //+kubebuilder:printcolumn:name="IpAddress",type=string,JSONPath=`.status.ipAddress`
-//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 //+kubebuilder:printcolumn:name="IpAssigned",type=string,JSONPath=`.status.conditions[?(@.type=="IPAssigned")].status`
+//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:resource:shortName=ipc
 
 // IpAddressClaim is the Schema for the ipaddressclaims API

--- a/api/v1/prefix_types.go
+++ b/api/v1/prefix_types.go
@@ -65,6 +65,7 @@ type PrefixStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.id`
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:resource:shortName=px
 // Prefix is the Schema for the prefixes API
 type Prefix struct {

--- a/api/v1/prefixclaim_types.go
+++ b/api/v1/prefixclaim_types.go
@@ -65,8 +65,9 @@ type PrefixClaimStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Prefix",type=string,JSONPath=`.status.prefix`
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="PrefixAssigned",type=string,JSONPath=`.status.conditions[?(@.type=="PrefixAssigned")].status`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:resource:shortName=pxc
 // PrefixClaim is the Schema for the prefixclaims API
 type PrefixClaim struct {

--- a/config/crd/bases/netbox.dev_ipaddressclaims.yaml
+++ b/config/crd/bases/netbox.dev_ipaddressclaims.yaml
@@ -20,12 +20,15 @@ spec:
     - jsonPath: .status.ipAddress
       name: IpAddress
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
     - jsonPath: .status.conditions[?(@.type=="IPAssigned")].status
       name: IpAssigned
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/netbox.dev_ipaddresses.yaml
+++ b/config/crd/bases/netbox.dev_ipaddresses.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.url
       name: URL
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/netbox.dev_prefixclaims.yaml
+++ b/config/crd/bases/netbox.dev_prefixclaims.yaml
@@ -20,12 +20,15 @@ spec:
     - jsonPath: .status.prefix
       name: Prefix
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
     - jsonPath: .status.conditions[?(@.type=="PrefixAssigned")].status
       name: PrefixAssigned
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/netbox.dev_prefixes.yaml
+++ b/config/crd/bases/netbox.dev_prefixes.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.url
       name: URL
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
A few UX changes:

- Adds an age column (with Kubebuilder this disappears from the CRD as soon as you add the first printcolumn)
- Orders the condition columns to feature the "Ready" condition as the last one

Before:

```bash
kubectl get ipc
NAME                    IPADDRESS    READY   IPASSIGNED
ipaddressclaim-sample   2.0.0.1/32   True    True
```

After:

```bash
kubectl get ipc
NAME                    IPADDRESS    IPASSIGNED   READY   AGE
ipaddressclaim-sample   2.0.0.1/32   True         True    4s
```