### PR TITLE
Fix: add logic to update site of prefix in netbox

### DIFF
--- a/api/v1/prefix_types.go
+++ b/api/v1/prefix_types.go
@@ -24,6 +24,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // PrefixSpec defines the desired state of Prefix
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.site) || has(self.site)", message="Site is required once set"
 type PrefixSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -33,6 +34,7 @@ type PrefixSpec struct {
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="Field 'prefix' is immutable"
 	Prefix string `json:"prefix"`
 
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf || self != ''",message="Field 'site' is required once set"
 	Site string `json:"site,omitempty"`
 
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="Field 'tenant' is immutable"

--- a/api/v1/prefixclaim_types.go
+++ b/api/v1/prefixclaim_types.go
@@ -24,6 +24,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // PrefixClaimSpec defines the desired state of PrefixClaim
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.site) || has(self.site)", message="Site is required once set"
 type PrefixClaimSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -38,6 +39,7 @@ type PrefixClaimSpec struct {
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="Field 'prefixLength' is immutable"
 	PrefixLength string `json:"prefixLength"`
 
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf || self != ''",message="Field 'site' is required once set"
 	Site string `json:"site,omitempty"`
 
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="Field 'tenant' is immutable"

--- a/config/crd/bases/netbox.dev_prefixclaims.yaml
+++ b/config/crd/bases/netbox.dev_prefixclaims.yaml
@@ -78,6 +78,9 @@ spec:
                 type: boolean
               site:
                 type: string
+                x-kubernetes-validations:
+                - message: Field 'site' is required once set
+                  rule: self == oldSelf || self != ''
               tenant:
                 type: string
                 x-kubernetes-validations:
@@ -87,6 +90,9 @@ spec:
             - parentPrefix
             - prefixLength
             type: object
+            x-kubernetes-validations:
+            - message: Site is required once set
+              rule: '!has(oldSelf.site) || has(self.site)'
           status:
             description: PrefixClaimStatus defines the observed state of PrefixClaim
             properties:

--- a/config/crd/bases/netbox.dev_prefixes.yaml
+++ b/config/crd/bases/netbox.dev_prefixes.yaml
@@ -75,6 +75,9 @@ spec:
                 type: boolean
               site:
                 type: string
+                x-kubernetes-validations:
+                - message: Field 'site' is required once set
+                  rule: self == oldSelf || self != ''
               tenant:
                 type: string
                 x-kubernetes-validations:
@@ -83,6 +86,9 @@ spec:
             required:
             - prefix
             type: object
+            x-kubernetes-validations:
+            - message: Site is required once set
+              rule: '!has(oldSelf.site) || has(self.site)'
           status:
             description: PrefixStatus defines the observed state of Prefix
             properties:

--- a/config/samples/netbox_v1_prefix.yaml
+++ b/config/samples/netbox_v1_prefix.yaml
@@ -7,7 +7,7 @@ metadata:
   name: prefix-sample
 spec:
   tenant: "Dunder-Mifflin, Inc."
-  site: "DataCenter"
+  site: "DM-Akron"
   description: "some description"
   comments: "your comments"
   preserveInNetbox: true

--- a/config/samples/netbox_v1_prefixclaim.yaml
+++ b/config/samples/netbox_v1_prefixclaim.yaml
@@ -7,7 +7,7 @@ metadata:
   name: prefixclaim-sample
 spec:
   tenant: "Dunder-Mifflin, Inc."
-  site: "DataCenter"
+  site: "DM-Akron"
   description: "some description"
   comments: "your comments"
   preserveInNetbox: true

--- a/gen/mock_interfaces/netbox_mocks.go
+++ b/gen/mock_interfaces/netbox_mocks.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	runtime "github.com/go-openapi/runtime"
+	dcim "github.com/netbox-community/go-netbox/v3/netbox/client/dcim"
 	extras "github.com/netbox-community/go-netbox/v3/netbox/client/extras"
 	ipam "github.com/netbox-community/go-netbox/v3/netbox/client/ipam"
 	tenancy "github.com/netbox-community/go-netbox/v3/netbox/client/tenancy"
@@ -23,6 +24,7 @@ import (
 type MockIpamInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockIpamInterfaceMockRecorder
+	isgomock struct{}
 }
 
 // MockIpamInterfaceMockRecorder is the mock recorder for MockIpamInterface.
@@ -246,6 +248,7 @@ func (mr *MockIpamInterfaceMockRecorder) IpamPrefixesUpdate(params, authInfo any
 type MockTenancyInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockTenancyInterfaceMockRecorder
+	isgomock struct{}
 }
 
 // MockTenancyInterfaceMockRecorder is the mock recorder for MockTenancyInterface.
@@ -289,6 +292,7 @@ func (mr *MockTenancyInterfaceMockRecorder) TenancyTenantsList(params, authInfo 
 type MockExtrasInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockExtrasInterfaceMockRecorder
+	isgomock struct{}
 }
 
 // MockExtrasInterfaceMockRecorder is the mock recorder for MockExtrasInterface.
@@ -326,4 +330,48 @@ func (mr *MockExtrasInterfaceMockRecorder) ExtrasCustomFieldsList(params, authIn
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{params, authInfo}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtrasCustomFieldsList", reflect.TypeOf((*MockExtrasInterface)(nil).ExtrasCustomFieldsList), varargs...)
+}
+
+// MockDcimInterface is a mock of DcimInterface interface.
+type MockDcimInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockDcimInterfaceMockRecorder
+	isgomock struct{}
+}
+
+// MockDcimInterfaceMockRecorder is the mock recorder for MockDcimInterface.
+type MockDcimInterfaceMockRecorder struct {
+	mock *MockDcimInterface
+}
+
+// NewMockDcimInterface creates a new mock instance.
+func NewMockDcimInterface(ctrl *gomock.Controller) *MockDcimInterface {
+	mock := &MockDcimInterface{ctrl: ctrl}
+	mock.recorder = &MockDcimInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDcimInterface) EXPECT() *MockDcimInterfaceMockRecorder {
+	return m.recorder
+}
+
+// DcimSitesList mocks base method.
+func (m *MockDcimInterface) DcimSitesList(params *dcim.DcimSitesListParams, authInfo runtime.ClientAuthInfoWriter, opts ...dcim.ClientOption) (*dcim.DcimSitesListOK, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{params, authInfo}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DcimSitesList", varargs...)
+	ret0, _ := ret[0].(*dcim.DcimSitesListOK)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DcimSitesList indicates an expected call of DcimSitesList.
+func (mr *MockDcimInterfaceMockRecorder) DcimSitesList(params, authInfo any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{params, authInfo}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DcimSitesList", reflect.TypeOf((*MockDcimInterface)(nil).DcimSitesList), varargs...)
 }

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -136,6 +136,7 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					PrefixLength: prefixClaim.Spec.PrefixLength,
 					Metadata: &models.NetboxMetadata{
 						Tenant: prefixClaim.Spec.Tenant,
+						Site:   prefixClaim.Spec.Site,
 					},
 				})
 			if err != nil {

--- a/internal/controller/prefixclaim_helpers.go
+++ b/internal/controller/prefixclaim_helpers.go
@@ -54,6 +54,7 @@ func generatePrefixSpec(claim *netboxv1.PrefixClaim, prefix string, logger logr.
 	return netboxv1.PrefixSpec{
 		Prefix:           prefix,
 		Tenant:           claim.Spec.Tenant,
+		Site:             claim.Spec.Site,
 		CustomFields:     customFields,
 		Description:      claim.Spec.Description,
 		Comments:         claim.Spec.Comments,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -58,6 +58,7 @@ var mockCtrl *gomock.Controller
 var ipamMockIpAddress *mock_interfaces.MockIpamInterface
 var ipamMockIpAddressClaim *mock_interfaces.MockIpamInterface
 var tenancyMock *mock_interfaces.MockTenancyInterface
+var dcimMock *mock_interfaces.MockDcimInterface
 var ctx context.Context
 var cancel context.CancelFunc
 
@@ -111,6 +112,7 @@ var _ = BeforeSuite(func() {
 	ipamMockIpAddress = mock_interfaces.NewMockIpamInterface(mockCtrl)
 	ipamMockIpAddressClaim = mock_interfaces.NewMockIpamInterface(mockCtrl)
 	tenancyMock = mock_interfaces.NewMockTenancyInterface(mockCtrl)
+	dcimMock = mock_interfaces.NewMockDcimInterface(mockCtrl)
 
 	k8sManager, err := ctrl.NewManager(cfg, k8sManagerOptions)
 	Expect(k8sManager.GetConfig()).NotTo(BeNil())
@@ -123,6 +125,7 @@ var _ = BeforeSuite(func() {
 		NetboxClient: &api.NetboxClient{
 			Ipam:    ipamMockIpAddress,
 			Tenancy: tenancyMock,
+			Dcim:    dcimMock,
 		},
 		OperatorNamespace: OperatorNamespace,
 		RestConfig:        k8sManager.GetConfig(),
@@ -136,6 +139,7 @@ var _ = BeforeSuite(func() {
 		NetboxClient: &api.NetboxClient{
 			Ipam:    ipamMockIpAddressClaim,
 			Tenancy: tenancyMock,
+			Dcim:    dcimMock,
 		},
 		OperatorNamespace: OperatorNamespace,
 		RestConfig:        k8sManager.GetConfig(),

--- a/pkg/netbox/api/client.go
+++ b/pkg/netbox/api/client.go
@@ -40,6 +40,7 @@ type NetboxClient struct {
 	Ipam    interfaces.IpamInterface
 	Tenancy interfaces.TenancyInterface
 	Extras  interfaces.ExtrasInterface
+	Dcim    interfaces.DcimInterface
 }
 
 // Checks that the Netbox host is properly configured for the operator to function.
@@ -108,6 +109,7 @@ func GetNetboxClient() (*NetboxClient, error) {
 		Ipam:    auxNetboxClient.Ipam,
 		Tenancy: auxNetboxClient.Tenancy,
 		Extras:  auxNetboxClient.Extras,
+		Dcim:    auxNetboxClient.Dcim,
 	}
 
 	return netboxClient, nil

--- a/pkg/netbox/api/ip_address_claim_test.go
+++ b/pkg/netbox/api/ip_address_claim_test.go
@@ -404,7 +404,7 @@ func TestIPAddressClaim_GetNoAvailableIPAddressWithTenancyChecks(t *testing.T) {
 		}
 
 		// expected error
-		expectedErrorMsg := "failed to fetch tenant: not found"
+		expectedErrorMsg := "failed to fetch tenant 'non-existing-tenant': not found"
 
 		// mock empty list call
 		mockTenancy.EXPECT().TenancyTenantsList(inputTenant, nil).Return(emptyTenantList, nil).AnyTimes()

--- a/pkg/netbox/api/prefix.go
+++ b/pkg/netbox/api/prefix.go
@@ -51,6 +51,14 @@ func (r *NetboxClient) ReserveOrUpdatePrefix(prefix *models.Prefix) (*netboxMode
 		desiredPrefix.Tenant = &tenantDetails.Id
 	}
 
+	if prefix.Metadata.Site != "" {
+		siteDetails, err := r.GetSiteDetails(prefix.Metadata.Site)
+		if err != nil {
+			return nil, err
+		}
+		desiredPrefix.Site = &siteDetails.Id
+	}
+
 	// create prefix since it doesn't exist
 	if len(responsePrefix.Payload.Results) == 0 {
 		return r.CreatePrefix(desiredPrefix)

--- a/pkg/netbox/api/prefix_claim.go
+++ b/pkg/netbox/api/prefix_claim.go
@@ -87,6 +87,14 @@ func (r *NetboxClient) GetAvailablePrefixByClaim(prefixClaim *models.PrefixClaim
 		return nil, err
 	}
 
+	// Don't assign an prefix if the requested site doesn't exist in netbox
+	if prefixClaim.Metadata.Site != "" {
+		_, err := r.GetSiteDetails(prefixClaim.Metadata.Site)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	responseParentPrefix, err := r.GetPrefix(&models.Prefix{
 		Prefix:   prefixClaim.ParentPrefix,
 		Metadata: prefixClaim.Metadata,

--- a/pkg/netbox/api/site.go
+++ b/pkg/netbox/api/site.go
@@ -17,23 +17,23 @@ limitations under the License.
 package api
 
 import (
-	"github.com/netbox-community/go-netbox/v3/netbox/client/tenancy"
+	"github.com/netbox-community/go-netbox/v3/netbox/client/dcim"
 
 	"github.com/netbox-community/netbox-operator/pkg/netbox/models"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/utils"
 )
 
-func (r *NetboxClient) GetTenantDetails(name string) (*models.Tenant, error) {
-	request := tenancy.NewTenancyTenantsListParams().WithName(&name)
-	response, err := r.Tenancy.TenancyTenantsList(request, nil)
+func (r *NetboxClient) GetSiteDetails(name string) (*models.Site, error) {
+	request := dcim.NewDcimSitesListParams().WithName(&name)
+	response, err := r.Dcim.DcimSitesList(request, nil)
 	if err != nil {
-		return nil, utils.NetboxError("failed to fetch Tenant details", err)
+		return nil, utils.NetboxError("failed to fetch Site details", err)
 	}
 	if len(response.Payload.Results) == 0 {
-		return nil, utils.NetboxNotFoundError("tenant '" + name + "'")
+		return nil, utils.NetboxNotFoundError("site '" + name + "'")
 	}
 
-	return &models.Tenant{
+	return &models.Site{
 		Id:   response.Payload.Results[0].ID,
 		Slug: *response.Payload.Results[0].Slug,
 		Name: *response.Payload.Results[0].Name,

--- a/pkg/netbox/api/site_test.go
+++ b/pkg/netbox/api/site_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 Swisscom (Schweiz) AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/netbox-community/netbox-operator/gen/mock_interfaces"
+
+	"github.com/netbox-community/go-netbox/v3/netbox/client/dcim"
+	netboxModels "github.com/netbox-community/go-netbox/v3/netbox/models"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSite_GetSiteDetails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDcim := mock_interfaces.NewMockDcimInterface(ctrl)
+
+	site := "mySite"
+
+	siteListRequestInput := dcim.NewDcimSitesListParams().WithName(&site)
+
+	siteOutputId := int64(1)
+	siteOutputSlug := "mysite"
+	siteListOutput := &dcim.DcimSitesListOK{
+		Payload: &dcim.DcimSitesListOKBody{
+			Results: []*netboxModels.Site{
+				{
+					ID:   siteOutputId,
+					Name: &site,
+					Slug: &siteOutputSlug,
+				},
+			},
+		},
+	}
+
+	mockDcim.EXPECT().DcimSitesList(siteListRequestInput, nil).Return(siteListOutput, nil)
+	netboxClient := &NetboxClient{Dcim: mockDcim}
+
+	actual, err := netboxClient.GetSiteDetails(site)
+	assert.NoError(t, err)
+	assert.Equal(t, site, actual.Name)
+	assert.Equal(t, siteOutputId, actual.Id)
+	assert.Equal(t, siteOutputSlug, actual.Slug)
+}
+
+func TestSite_GetEmptyResult(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDcim := mock_interfaces.NewMockDcimInterface(ctrl)
+
+	site := "mySite"
+
+	siteListRequestInput := dcim.NewDcimSitesListParams().WithName(&site)
+
+	emptyListSiteOutput := &dcim.DcimSitesListOK{
+		Payload: &dcim.DcimSitesListOKBody{
+			Results: []*netboxModels.Site{},
+		},
+	}
+
+	mockDcim.EXPECT().DcimSitesList(siteListRequestInput, nil).Return(emptyListSiteOutput, nil)
+	netboxClient := &NetboxClient{Dcim: mockDcim}
+
+	actual, err := netboxClient.GetSiteDetails(site)
+	assert.Nil(t, actual)
+	assert.EqualError(t, err, "failed to fetch site 'mySite': not found")
+}
+
+func TestSite_GetError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDcim := mock_interfaces.NewMockDcimInterface(ctrl)
+
+	site := "mySite"
+
+	siteListRequestInput := dcim.NewDcimSitesListParams().WithName(&site)
+
+	expectedErr := "error geting sites list"
+
+	mockDcim.EXPECT().DcimSitesList(siteListRequestInput, nil).Return(nil, errors.New(expectedErr))
+	netboxClient := &NetboxClient{Dcim: mockDcim}
+
+	actual, err := netboxClient.GetSiteDetails(site)
+	assert.Nil(t, actual)
+	assert.EqualError(t, err, "failed to fetch Site details: "+expectedErr)
+}

--- a/pkg/netbox/api/tenancy_test.go
+++ b/pkg/netbox/api/tenancy_test.go
@@ -80,5 +80,5 @@ func TestTenancy_GetWrongTenantDetails(t *testing.T) {
 
 	actual, err := netboxClient.GetTenantDetails(wrongTenant)
 	assert.Nil(t, actual)
-	assert.EqualError(t, err, "failed to fetch tenant: not found")
+	assert.EqualError(t, err, "failed to fetch tenant 'wrongTenant': not found")
 }

--- a/pkg/netbox/interfaces/netbox.go
+++ b/pkg/netbox/interfaces/netbox.go
@@ -18,6 +18,7 @@ package interfaces
 
 import (
 	"github.com/go-openapi/runtime"
+	"github.com/netbox-community/go-netbox/v3/netbox/client/dcim"
 	"github.com/netbox-community/go-netbox/v3/netbox/client/extras"
 	"github.com/netbox-community/go-netbox/v3/netbox/client/ipam"
 	"github.com/netbox-community/go-netbox/v3/netbox/client/tenancy"
@@ -43,4 +44,8 @@ type TenancyInterface interface {
 
 type ExtrasInterface interface {
 	ExtrasCustomFieldsList(params *extras.ExtrasCustomFieldsListParams, authInfo runtime.ClientAuthInfoWriter, opts ...extras.ClientOption) (*extras.ExtrasCustomFieldsListOK, error)
+}
+
+type DcimInterface interface {
+	DcimSitesList(params *dcim.DcimSitesListParams, authInfo runtime.ClientAuthInfoWriter, opts ...dcim.ClientOption) (*dcim.DcimSitesListOK, error)
 }

--- a/pkg/netbox/models/ipam.go
+++ b/pkg/netbox/models/ipam.go
@@ -22,6 +22,12 @@ type Tenant struct {
 	Slug string `json:"slug,omitempty"`
 }
 
+type Site struct {
+	Id   int64  `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+	Slug string `json:"slug,omitempty"`
+}
+
 type NetboxMetadata struct {
 	Comments    string            `json:"comments,omitempty"`
 	Custom      map[string]string `json:"customFields,omitempty"`


### PR DESCRIPTION
Currently, the site that is set in a prefixclaim CR is not updated in NetBox. This PR focuses on fixing the underlying logic to ensure accurate updates.

Using the go-netbox client the site is not removed from the resource in NetBox with the IpamPrefixesUpdate function. To avoid inconsistent state between the Prefix CR and the Prefix Resource in NetBox a validation rule was added to the prefix type which does not allow the deletion of the site field once it was created.