### PR TITLE
removed group name from existing crd's

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -13,7 +13,6 @@ resources:
     namespaced: true
   controller: true
   domain: netbox.dev
-  group: netbox
   kind: IpAddress
   path: github.com/netbox-community/netbox-operator/api/v1
   version: v1
@@ -22,7 +21,6 @@ resources:
     namespaced: true
   controller: true
   domain: netbox.dev
-  group: netbox
   kind: IpAddressClaim
   path: github.com/netbox-community/netbox-operator/api/v1
   version: v1
@@ -31,7 +29,6 @@ resources:
     namespaced: true
   controller: true
   domain: netbox.dev
-  group: netbox
   kind: Prefix
   path: github.com/netbox-community/netbox-operator/api/v1
   version: v1
@@ -40,7 +37,6 @@ resources:
     namespaced: true
   controller: true
   domain: netbox.dev
-  group: netbox
   kind: PrefixClaim
   path: github.com/netbox-community/netbox-operator/api/v1
   version: v1


### PR DESCRIPTION
Fixes #66
New CRD's can be generated either without group name, like the existing ones or with group names by enabling multi-group support