### PR TITLE
Add support for built-in field `family` in `ParentPrefixSelector`

### DIFF
--- a/ParentPrefixSelectorGuide.md
+++ b/ParentPrefixSelectorGuide.md
@@ -28,6 +28,7 @@ spec:
   parentPrefixSelector: 
     tenant: "MY_TENANT"
     site: "DM-Buffalo"
+    family: "IPv4"
     environment: "Production"
     poolName: "Pool 1"
 ```
@@ -47,10 +48,10 @@ The map contains a set of query conditions for selecting a set of prefixes that 
 The query conditions will be chained by the AND operator, and exact match of the keys and values will be performed.
 
 The fields that can be used as query conditions in the `parentPrefixSelector` are:
-- `tenant` and `site` (in lowercase characters)
-    - these 2 fields are built-in fields from NetBox, so you do *not* need to create custom fields for them
-    - please provide the *name*, not the *slug* value
-    - if the entry for tenant or site is missing, it will *not* inherit from the tenant and site from the Spec
+- `tenant`, `site`, and `family` (in lowercase characters)
+    - these fields are built-in fields from NetBox, so you do *not* need to create custom fields for them
+    - please provide the *name*, not the *slug* value for `tenant` and `site`
+    - if the entry for `tenant` and `site` fields is missing, it will *not* inherit from the Spec
 - custom fields
     - the data types tested and supported so far are `string`, `integer`, and `boolean`
     - for `boolean` type, please use `true` and `false` as the value

--- a/api/v1/prefixclaim_types.go
+++ b/api/v1/prefixclaim_types.go
@@ -39,9 +39,10 @@ type PrefixClaimSpec struct {
 	// The `parentPrefixSelector` is a key-value map, where all the entries are of data type `<string-string>`
 	// The map contains a set of query conditions for selecting a set of prefixes that can be used as the parent prefix
 	// The query conditions will be chained by the AND operator, and exact match of the keys and values will be performed
-	// 2 built-in fields, namely `tenant` and `site`, along with custom fields, can be used
+	// The built-in fields `tenant`, `site`, and `family`, along with custom fields, can be used
 	// For more information, please see ParentPrefixSelectorGuide.md
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="Field 'parentPrefixSelector' is immutable"
+	//+kubebuilder:validation:XValidation:rule="!has(self.family) || (self.family == 'IPv4' || self.family == 'IPv6')"
 	ParentPrefixSelector map[string]string `json:"parentPrefixSelector,omitempty"`
 
 	//+kubebuilder:validation:Required

--- a/config/crd/bases/netbox.dev_prefixclaims.yaml
+++ b/config/crd/bases/netbox.dev_prefixclaims.yaml
@@ -77,12 +77,14 @@ spec:
                   The `parentPrefixSelector` is a key-value map, where all the entries are of data type `<string-string>`
                   The map contains a set of query conditions for selecting a set of prefixes that can be used as the parent prefix
                   The query conditions will be chained by the AND operator, and exact match of the keys and values will be performed
-                  2 built-in fields, namely `tenant` and `site`, along with custom fields, can be used
+                  The built-in fields `tenant`, `site`, and `family`, along with custom fields, can be used
                   For more information, please see ParentPrefixSelectorGuide.md
                 type: object
                 x-kubernetes-validations:
                 - message: Field 'parentPrefixSelector' is immutable
                   rule: self == oldSelf
+                - rule: '!has(self.family) || (self.family == ''IPv4'' || self.family
+                    == ''IPv6'')'
               prefixLength:
                 pattern: ^\/[0-9]|[1-9][0-9]|1[01][0-9]|12[0-8]$
                 type: string

--- a/config/samples/netbox_v1_prefixclaim_parentprefixselector.yaml
+++ b/config/samples/netbox_v1_prefixclaim_parentprefixselector.yaml
@@ -16,6 +16,7 @@ spec:
     # if the entry for tenant or site is missing, it will *not* inherit from the tenant and site from the Spec
     tenant: "MY_TENANT" # Use the `name` value instead of the `slug` value
     site: "DM-Buffalo" # Use the `name` value instead of the `slug` value
+    family: "IPv4" # Can only be either IPv4 or IPv6"
     
     # custom fields of your interest
     environment: "Production"

--- a/pkg/netbox/api/errors.go
+++ b/pkg/netbox/api/errors.go
@@ -22,4 +22,5 @@ var (
 	ErrParentPrefixExhausted           = errors.New("parent prefix exhausted")
 	ErrParentPrefixNotFound            = errors.New("parent prefix not found")
 	ErrWrongMatchingPrefixSubnetFormat = errors.New("wrong matchingPrefix subnet format")
+	ErrInvalidIpFamily                 = errors.New("invalid IP Family")
 )

--- a/pkg/netbox/api/prefix_claim.go
+++ b/pkg/netbox/api/prefix_claim.go
@@ -114,6 +114,17 @@ func (r *NetboxClient) GetAvailablePrefixByParentPrefixSelector(prefixClaimSpec 
 		fieldEntries["site_id"] = strconv.Itoa(int(details.Id))
 	}
 
+	if family, ok := prefixClaimSpec.ParentPrefixSelector["family"]; ok {
+		if family == "IPv4" {
+			family = "4"
+		} else if family == "IPv6" {
+			family = "6"
+		} else {
+			return nil, ErrInvalidIpFamily
+		}
+		fieldEntries["family"] = family
+	}
+
 	var conditions func(co *runtime.ClientOperation)
 	parentPrefixSelectorEntries := make([]CustomFieldEntry, 0, len(prefixClaimSpec.ParentPrefixSelector))
 	for k, v := range prefixClaimSpec.ParentPrefixSelector {


### PR DESCRIPTION
Added support for the built-in field `family` in `ParentPrefixSelector`.

The CR validation is also written to reject values besides `IPv4` and `IPv6`, when the key `family` is present in `ParentPrefixSelector`.

The documentation and the sample CR are also updated.