### PR TITLE
Cancel running workflow when new commits are pushed in a pull request

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - v*
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   IMAGE_NAME: netbox-operator
   DOCKER_METADATA_PR_HEAD_SHA: true

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - v*
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions: read-all
 jobs:
   test:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - v*
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - v*
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions: read-all
 jobs:
   run:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - v*
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Reduce noise in the case that CI jobs failed when new commits are pushed before the previous one's CI job has finished