### PR TITLE
Add part-of label to metrics monitor service labelSelector

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/part-of: netbox-operator
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -23,3 +23,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/part-of: netbox-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -19,3 +19,4 @@ spec:
     targetPort: https
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/part-of: netbox-operator


### PR DESCRIPTION
add the 'app.kubernetes.io/part-of: netbox-operator' to the pod template and the metrics monitor service