### PR TITLE
[CI] Do not cancel concurrent CI jobs on main

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 env:
   IMAGE_NAME: netbox-operator
   DOCKER_METADATA_PR_HEAD_SHA: true

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 env:
   NETBOX_HOST: demo.netbox.dev
   AUTH_TOKEN: 0123456789abcdef0123456789abcdef01234567

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 permissions: read-all
 jobs:
   test:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 permissions: read-all
 jobs:
   run:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
When we merge a PR into the main branch before the previously merged commit finishes, the CI jobs will be cancelled (see https://github.com/netbox-community/netbox-operator/commits/main/), which is not ideal as we would like to see if all commits merged into the main branch can pass CI checks.