### PR TITLE
Fix CI runs being cancelled on main branch

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 env:
   IMAGE_NAME: netbox-operator
   DOCKER_METADATA_PR_HEAD_SHA: true

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 env:
   NETBOX_HOST: demo.netbox.dev
   AUTH_TOKEN: 0123456789abcdef0123456789abcdef01234567

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 permissions: read-all
 jobs:
   test:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 permissions: read-all
 jobs:
   run:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -7,9 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main/')}}
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Revert https://github.com/netbox-community/netbox-operator/pull/160 (For some reason, https://github.com/netbox-community/netbox-operator/pull/221 fails to address the cancellation on CI runs against main branch).

Our docker images being pushed to the GitHub registry relies on the CI runs against the main branch, so we need to ensure that the CI runs on main branch is always running without any hiccups.



