### PR TITLE
Make e2e tests idempotent

### DIFF
--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithIPv4ParentPrefixSelectorWhenAppliedThenSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithIPv4ParentPrefixSelectorWhenAppliedThenSucceed/chainsaw-test.yaml
@@ -53,14 +53,6 @@ spec:
                 name: prefixclaim-ipv4-parentprefixselector-sample
               spec:
                 preserveInNetbox: false
-        - patch:
-            resource:
-              apiVersion: netbox.dev/v1
-              kind: Prefix
-              metadata:
-                name: prefixclaim-ipv4-parentprefixselector-sample
-              spec:
-                preserveInNetbox: false
         - assert:
             resource:
               apiVersion: netbox.dev/v1

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithIPv4ParentPrefixSelectorWhenAppliedThenSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithIPv4ParentPrefixSelectorWhenAppliedThenSucceed/chainsaw-test.yaml
@@ -45,3 +45,35 @@ spec:
                 tenant: MY_TENANT_2
                 customFields:
                   netboxOperatorRestorationHash: e3ea4eebe4ab49cc7c91dc9f96007965ede43338
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sample
+              spec:
+                preserveInNetbox: false
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sample
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sample
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sample
+              spec:
+                (preserveInNetbox == true): false

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedDeletedAppliedThenRestorationSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedDeletedAppliedThenRestorationSucceed/chainsaw-test.yaml
@@ -56,7 +56,6 @@ spec:
                 description: some description
                 parentPrefix: 2.0.3.0/24
                 prefixLength: /28
-                preserveInNetbox: true
                 site: MY_SITE
                 tenant: MY_TENANT
               status:
@@ -73,7 +72,6 @@ spec:
                 comments: your comments
                 description: some description
                 prefix: 2.0.3.16/28
-                preserveInNetbox: true
                 site: MY_SITE
                 tenant: MY_TENANT
                 customFields:
@@ -87,10 +85,10 @@ spec:
               kind: PrefixClaim
               name: prefixclaim-ipv4-apply-delete-apply-restored-1
     - name: Apply prefix claim CR 1 for the second time and check after deletion and reapply of CR 1
-      description: 
+      description:
       try:
         - apply:
-            file: netbox_v1_prefixclaim_1.yaml      
+            file: netbox_v1_prefixclaim_1.yaml
         - assert:
             resource:
               apiVersion: netbox.dev/v1
@@ -135,7 +133,6 @@ spec:
                 description: some description
                 parentPrefix: 2.0.3.0/24
                 prefixLength: /28
-                preserveInNetbox: true
                 site: MY_SITE
                 tenant: MY_TENANT
               status:
@@ -152,8 +149,39 @@ spec:
                 comments: your comments
                 description: some description
                 prefix: 2.0.3.16/28
-                preserveInNetbox: true
                 site: MY_SITE
                 tenant: MY_TENANT
                 customFields:
                   netboxOperatorRestorationHash: 0265a1eec7bba9748f9542476fe3dccb46cceb5a
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-apply-delete-apply-restored-1
+              spec:
+                preserveInNetbox: false
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-apply-delete-apply-restored-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-apply-delete-apply-restored-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-apply-delete-apply-restored-1
+              spec:
+                (preserveInNetbox == true): false

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedDeletedAppliedThenRestorationSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedDeletedAppliedThenRestorationSucceed/chainsaw-test.yaml
@@ -161,14 +161,6 @@ spec:
                 name: prefixclaim-ipv4-apply-delete-apply-restored-1
               spec:
                 preserveInNetbox: false
-        - patch:
-            resource:
-              apiVersion: netbox.dev/v1
-              kind: Prefix
-              metadata:
-                name: prefixclaim-ipv4-apply-delete-apply-restored-1
-              spec:
-                preserveInNetbox: false
         - assert:
             resource:
               apiVersion: netbox.dev/v1

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedDeletedAppliedThenRestorationSucceed/netbox_v1_prefixclaim_2.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedDeletedAppliedThenRestorationSucceed/netbox_v1_prefixclaim_2.yaml
@@ -10,6 +10,6 @@ spec:
   site: "MY_SITE"
   description: "some description"
   comments: "your comments"
-  preserveInNetbox: true
+  preserveInNetbox: false
   parentPrefix: "2.0.3.0/24"
   prefixLength: "/28"

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedThenSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedThenSucceed/chainsaw-test.yaml
@@ -49,14 +49,6 @@ spec:
                 name: prefixclaim-ipv4-apply
               spec:
                 preserveInNetbox: false
-        - patch:
-            resource:
-              apiVersion: netbox.dev/v1
-              kind: Prefix
-              metadata:
-                name: prefixclaim-ipv4-apply
-              spec:
-                preserveInNetbox: false
         - assert:
             resource:
               apiVersion: netbox.dev/v1

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedThenSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenAppliedThenSucceed/chainsaw-test.yaml
@@ -41,3 +41,35 @@ spec:
                 tenant: MY_TENANT
                 customFields:
                   netboxOperatorRestorationHash: f773cf04f71c017931716e125a8520d70f4c7f83
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-apply
+              spec:
+                preserveInNetbox: false
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-apply
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-apply
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-apply
+              spec:
+                (preserveInNetbox == true): false

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenParentPrefixSelectorAppliedDeletedAppliedThenRestorationSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenParentPrefixSelectorAppliedDeletedAppliedThenRestorationSucceed/chainsaw-test.yaml
@@ -66,7 +66,6 @@ spec:
                   site: MY_SITE
                   tenant: MY_TENANT
                 prefixLength: /28
-                preserveInNetbox: true
                 site: MY_SITE_2
                 tenant: MY_TENANT_2
               status:
@@ -83,7 +82,6 @@ spec:
                 comments: your comments
                 description: some description
                 prefix: 3.0.4.16/28
-                preserveInNetbox: true
                 site: MY_SITE_2
                 tenant: MY_TENANT_2
                 customFields:
@@ -97,10 +95,10 @@ spec:
               kind: PrefixClaim
               name: prefixclaim-ipv4-parentprefixselector-apply-delete-apply-restored-1
     - name: Apply prefix claim CR 1 for the second time and check after deletion and reapply of CR 1
-      description: 
+      description:
       try:
         - apply:
-            file: netbox_v1_prefixclaim_1.yaml      
+            file: netbox_v1_prefixclaim_1.yaml
         - assert:
             resource:
               apiVersion: netbox.dev/v1
@@ -155,7 +153,6 @@ spec:
                   site: MY_SITE
                   tenant: MY_TENANT
                 prefixLength: /28
-                preserveInNetbox: true
                 site: MY_SITE_2
                 tenant: MY_TENANT_2
               status:
@@ -172,8 +169,39 @@ spec:
                 comments: your comments
                 description: some description
                 prefix: 3.0.4.16/28
-                preserveInNetbox: true
                 site: MY_SITE_2
                 tenant: MY_TENANT_2
                 customFields:
                   netboxOperatorRestorationHash: 2fecef786a6c3590bc219c540d2a142f9e2ad907
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-apply-delete-apply-restored-1
+              spec:
+                preserveInNetbox: false
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-apply-delete-apply-restored-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-apply-delete-apply-restored-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-apply-delete-apply-restored-1
+              spec:
+                (preserveInNetbox == true): false

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenParentPrefixSelectorAppliedDeletedAppliedThenRestorationSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenParentPrefixSelectorAppliedDeletedAppliedThenRestorationSucceed/chainsaw-test.yaml
@@ -181,14 +181,6 @@ spec:
                 name: prefixclaim-ipv4-parentprefixselector-apply-delete-apply-restored-1
               spec:
                 preserveInNetbox: false
-        - patch:
-            resource:
-              apiVersion: netbox.dev/v1
-              kind: Prefix
-              metadata:
-                name: prefixclaim-ipv4-parentprefixselector-apply-delete-apply-restored-1
-              spec:
-                preserveInNetbox: false
         - assert:
             resource:
               apiVersion: netbox.dev/v1

--- a/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenParentPrefixSelectorAppliedDeletedAppliedThenRestorationSucceed/netbox_v1_prefixclaim_2.yaml
+++ b/tests/e2e/Prefix/IPv4/GivenPrefixClaimWithPreserveWhenParentPrefixSelectorAppliedDeletedAppliedThenRestorationSucceed/netbox_v1_prefixclaim_2.yaml
@@ -10,7 +10,7 @@ spec:
   site: "MY_SITE_2"
   description: "some description"
   comments: "your comments"
-  preserveInNetbox: true
+  preserveInNetbox: false
   prefixLength: "/28"
   parentPrefixSelector: # The keys and values are case-sensitive
     tenant: "MY_TENANT" # Use the `name` value instead of the `slug` value

--- a/tests/e2e/Prefix/IPv6/GivenPrefixClaimWithIPv6ParentPrefixSelectorWhenAppliedThenSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv6/GivenPrefixClaimWithIPv6ParentPrefixSelectorWhenAppliedThenSucceed/chainsaw-test.yaml
@@ -47,3 +47,35 @@ spec:
                 tenant: MY_TENANT_2
                 customFields:
                   netboxOperatorRestorationHash: 92913dac42ca35232682325c7f04639959d3a3cf
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv6-parentprefixselector-apply-succeed
+              spec:
+                preserveInNetbox: false
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv6-parentprefixselector-apply-succeed
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv6-parentprefixselector-apply-succeed
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv6-parentprefixselector-apply-succeed
+              spec:
+                (preserveInNetbox == true): false

--- a/tests/e2e/Prefix/IPv6/GivenPrefixClaimWithIPv6ParentPrefixSelectorWhenAppliedThenSucceed/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv6/GivenPrefixClaimWithIPv6ParentPrefixSelectorWhenAppliedThenSucceed/chainsaw-test.yaml
@@ -55,14 +55,6 @@ spec:
                 name: prefixclaim-ipv6-parentprefixselector-apply-succeed
               spec:
                 preserveInNetbox: false
-        - patch:
-            resource:
-              apiVersion: netbox.dev/v1
-              kind: Prefix
-              metadata:
-                name: prefixclaim-ipv6-parentprefixselector-apply-succeed
-              spec:
-                preserveInNetbox: false
         - assert:
             resource:
               apiVersion: netbox.dev/v1


### PR DESCRIPTION
Goal: Make the e2e itempotent so we don't have to manually clean up NetBox to make the tests work.

The idea is to patch .spec.preserveInNetbox of the claim, then assert that .spec.preserveInNetbox of the non-Claim is not true before exiting the test (and cleaning up the k8s resources). This is currently not possible for unknown reasons. Observations/Theories:
- Observation: The tests fail non-deterministically and in NetBox there are leftovers.
- Observation: The number of failed tests and the number of leftovers in NetBox does not correlate. e.g. it's possible all tests are successful but there are leftovers.
- There is something weird with booleans, json serialisation and validation in Golang/CRDs: https://github.com/go-playground/validator/issues/319
- Theory: The cached client of chainsaw and NetBox Operator are out of sync, chainsaw observes the .spec.preserveInNetbox=false and cleans up the resources while NetBox Operator still has the old state with .spec.preserveInNetbox=true and thus does not clean up things in NetBox.
- Theory: There is an issue in the Claim Controller updating the non-Claim spec in time

Another approach to solve this would be to run a script in the cleanup block of the tests that cleans up resources directly in NetBox e.g. everything that contains the "e2e/" prefix in the description. The advantage of this would be that we don't misuse the chainsaw test itself for cleanup.