### PR TITLE
Remove duplicate kind cluster creation

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -25,14 +25,6 @@ jobs:
     - name: Import environment variables from file
       run: |
         cat ".github/env" >> "$GITHUB_ENV"
-    - name: Start kind cluster
-      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
-      with:
-        version: ${{ env.kind-version }}
-        node_image: ${{ env.kind-image }}
-        wait: 300s
-        config: ./tests/e2e/kind-config.yaml
-        cluster_name: e2e
     - name: Wait for cluster to finish bootstraping
       run: |
         echo "Waiting for all nodes to be ready..."
@@ -57,14 +49,6 @@ jobs:
     - name: Import environment variables from file
       run: |
         cat ".github/env" >> "$GITHUB_ENV"
-    - name: Start kind cluster
-      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
-      with:
-        version: ${{ env.kind-version }}
-        node_image: ${{ env.kind-image }}
-        wait: 300s
-        config: ./tests/e2e/kind-config.yaml
-        cluster_name: e2e
     - name: Wait for cluster to finish bootstraping
       run: |
         echo "Waiting for all nodes to be ready..."
@@ -89,14 +73,6 @@ jobs:
     - name: Import environment variables from file
       run: |
         cat ".github/env" >> "$GITHUB_ENV"
-    - name: Start kind cluster
-      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
-      with:
-        version: ${{ env.kind-version }}
-        node_image: ${{ env.kind-image }}
-        wait: 300s
-        config: ./tests/e2e/kind-config.yaml
-        cluster_name: e2e
     - name: Wait for cluster to finish bootstraping
       run: |
         echo "Waiting for all nodes to be ready..."

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -25,16 +25,6 @@ jobs:
     - name: Import environment variables from file
       run: |
         cat ".github/env" >> "$GITHUB_ENV"
-    - name: Wait for cluster to finish bootstraping
-      run: |
-        echo "Waiting for all nodes to be ready..."
-        kubectl wait --for=condition=Ready nodes --all --timeout=120s
-        kubectl get nodes
-        echo "Waiting for all pods to be ready..."
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
-        kubectl get pods -A
-        echo "Cluster information"
-        kubectl cluster-info
     - name: Run e2e tests
       run: |
         make test-e2e-3.7.8
@@ -49,16 +39,6 @@ jobs:
     - name: Import environment variables from file
       run: |
         cat ".github/env" >> "$GITHUB_ENV"
-    - name: Wait for cluster to finish bootstraping
-      run: |
-        echo "Waiting for all nodes to be ready..."
-        kubectl wait --for=condition=Ready nodes --all --timeout=120s
-        kubectl get nodes
-        echo "Waiting for all pods to be ready..."
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
-        kubectl get pods -A
-        echo "Cluster information"
-        kubectl cluster-info
     - name: Run e2e tests
       run: |
         make test-e2e-4.0.11
@@ -73,16 +53,6 @@ jobs:
     - name: Import environment variables from file
       run: |
         cat ".github/env" >> "$GITHUB_ENV"
-    - name: Wait for cluster to finish bootstraping
-      run: |
-        echo "Waiting for all nodes to be ready..."
-        kubectl wait --for=condition=Ready nodes --all --timeout=120s
-        kubectl get nodes
-        echo "Waiting for all pods to be ready..."
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
-        kubectl get pods -A
-        echo "Cluster information"
-        kubectl cluster-info
     - name: Run e2e tests
       run: |
         make test-e2e-4.1.8


### PR DESCRIPTION
Kind clusters for the e2e tests are implicitly created in the `make test-e2e-*` targets that are triggered in the `Run e2e tests` steps of the `e2e-tests` pipeline. Thus, there is no need for the additional `Start kind cluster` step in the e2e tests pipeline. This PR removes the additional kind cluster creation.