### PR TITLE
Consolidate Status and Condition reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ There are several ways to install NetBox Operator on your Cluster:
 
 ## Running both NetBox Operator and NetBox on a local kind cluster
 
-Note: This requires Docker BuildKit.
+> **Note:** This requires Docker BuildKit.
+
+> **Note:** There is currently a bug where if Docker uses containerd for pulling and storing images, kind fails to load the image into the cluster ([GitHub Issue](https://github.com/kubernetes-sigs/kind/issues/3795)).
+To resolve this, temporarily disable this option in the Docker settings: "General > Use containerd for pulling and storing images"
 
 - Create kind cluster with a NetBox deployment: `make create-kind`
 - Deploy the NetBox Operator on the local kind cluster: `make deploy-kind` (In case you're using podman use `CONTAINER_TOOL=podman make deploy-kind`)

--- a/api/v1/ipaddress_types.go
+++ b/api/v1/ipaddress_types.go
@@ -99,6 +99,10 @@ type IpAddress struct {
 	Status IpAddressStatus `json:"status,omitempty"`
 }
 
+func (i *IpAddress) Conditions() *[]metav1.Condition {
+	return &i.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // IpAddressList contains a list of IpAddress

--- a/api/v1/ipaddressclaim_types.go
+++ b/api/v1/ipaddressclaim_types.go
@@ -104,6 +104,10 @@ type IpAddressClaim struct {
 	Status IpAddressClaimStatus `json:"status,omitempty"`
 }
 
+func (i *IpAddressClaim) Conditions() *[]metav1.Condition {
+	return &i.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // IpAddressClaimList contains a list of IpAddressClaim

--- a/api/v1/iprange_types.go
+++ b/api/v1/iprange_types.go
@@ -108,6 +108,10 @@ type IpRange struct {
 	Status IpRangeStatus `json:"status,omitempty"`
 }
 
+func (i *IpRange) Conditions() *[]metav1.Condition {
+	return &i.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // IpRangeList contains a list of IpRange

--- a/api/v1/iprangeclaim_types.go
+++ b/api/v1/iprangeclaim_types.go
@@ -133,6 +133,10 @@ type IpRangeClaim struct {
 	Status IpRangeClaimStatus `json:"status,omitempty"`
 }
 
+func (i *IpRangeClaim) Conditions() *[]metav1.Condition {
+	return &i.Status.Conditions
+}
+
 //+kubebuilder:object:root=true
 
 // IpRangeClaimList contains a list of IpRangeClaim

--- a/api/v1/prefix_types.go
+++ b/api/v1/prefix_types.go
@@ -104,8 +104,8 @@ type Prefix struct {
 	Status PrefixStatus `json:"status,omitempty"`
 }
 
-func (i *Prefix) Conditions() *[]metav1.Condition {
-	return &i.Status.Conditions
+func (p *Prefix) Conditions() *[]metav1.Condition {
+	return &p.Status.Conditions
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1/prefix_types.go
+++ b/api/v1/prefix_types.go
@@ -104,6 +104,10 @@ type Prefix struct {
 	Status PrefixStatus `json:"status,omitempty"`
 }
 
+func (i *Prefix) Conditions() *[]metav1.Condition {
+	return &i.Status.Conditions
+}
+
 // +kubebuilder:object:root=true
 
 // PrefixList contains a list of Prefix

--- a/api/v1/prefixclaim_types.go
+++ b/api/v1/prefixclaim_types.go
@@ -132,8 +132,8 @@ type PrefixClaim struct {
 	Status PrefixClaimStatus `json:"status,omitempty"`
 }
 
-func (i *PrefixClaim) Conditions() *[]metav1.Condition {
-	return &i.Status.Conditions
+func (p *PrefixClaim) Conditions() *[]metav1.Condition {
+	return &p.Status.Conditions
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1/prefixclaim_types.go
+++ b/api/v1/prefixclaim_types.go
@@ -132,6 +132,10 @@ type PrefixClaim struct {
 	Status PrefixClaimStatus `json:"status,omitempty"`
 }
 
+func (i *PrefixClaim) Conditions() *[]metav1.Condition {
+	return &i.Status.Conditions
+}
+
 // +kubebuilder:object:root=true
 
 // PrefixClaimList contains a list of PrefixClaim

--- a/api/v1/shared_conditions.go
+++ b/api/v1/shared_conditions.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Swisscom (Schweiz) AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/api/v1/shared_conditions.go
+++ b/api/v1/shared_conditions.go
@@ -1,0 +1,10 @@
+package v1
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+var ConditionReadyFalseNewResource = metav1.Condition{
+	Type:    "Ready",
+	Status:  "False",
+	Reason:  "NewResource",
+	Message: "Pending Reconciliation",
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -168,67 +168,67 @@ func main() {
 	}
 
 	if err = (&controller.IpAddressReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorderFor("ip-address-controller"),
-		NetboxClient:      netboxClient,
-		OperatorNamespace: operatorNamespace,
-		RestConfig:        mgr.GetConfig(),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		EventStatusRecorder: controller.NewEventStatusRecorder(mgr.GetClient(), mgr.GetEventRecorderFor("ip-address-controller")),
+		NetboxClient:        netboxClient,
+		OperatorNamespace:   operatorNamespace,
+		RestConfig:          mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IpAddress")
 		os.Exit(1)
 	}
 	if err = (&controller.IpAddressClaimReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorderFor("ip-address-claim-controller"),
-		NetboxClient:      netboxClient,
-		OperatorNamespace: operatorNamespace,
-		RestConfig:        mgr.GetConfig(),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		EventStatusRecorder: controller.NewEventStatusRecorder(mgr.GetClient(), mgr.GetEventRecorderFor("ip-address-claim-controller")),
+		NetboxClient:        netboxClient,
+		OperatorNamespace:   operatorNamespace,
+		RestConfig:          mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IpAddressClaim")
 		os.Exit(1)
 	}
 	if err = (&controller.PrefixReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorderFor("prefix-controller"),
-		NetboxClient:      netboxClient,
-		OperatorNamespace: operatorNamespace,
-		RestConfig:        mgr.GetConfig(),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		EventStatusRecorder: controller.NewEventStatusRecorder(mgr.GetClient(), mgr.GetEventRecorderFor("prefix-controller")),
+		NetboxClient:        netboxClient,
+		OperatorNamespace:   operatorNamespace,
+		RestConfig:          mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Prefix")
 		os.Exit(1)
 	}
 	if err = (&controller.PrefixClaimReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorderFor("prefix-claim-controller"),
-		NetboxClient:      netboxClient,
-		OperatorNamespace: operatorNamespace,
-		RestConfig:        mgr.GetConfig(),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		EventStatusRecorder: controller.NewEventStatusRecorder(mgr.GetClient(), mgr.GetEventRecorderFor("prefix-claim-controller")),
+		NetboxClient:        netboxClient,
+		OperatorNamespace:   operatorNamespace,
+		RestConfig:          mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PrefixClaim")
 		os.Exit(1)
 	}
 	if err = (&controller.IpRangeClaimReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorderFor("ip-range-claim-controller"),
-		NetboxClient:      netboxClient,
-		OperatorNamespace: operatorNamespace,
-		RestConfig:        mgr.GetConfig(),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		EventStatusRecorder: controller.NewEventStatusRecorder(mgr.GetClient(), mgr.GetEventRecorderFor("ip-range-claim-controller")),
+		NetboxClient:        netboxClient,
+		OperatorNamespace:   operatorNamespace,
+		RestConfig:          mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IpRangeClaim")
 		os.Exit(1)
 	}
 	if err = (&controller.IpRangeReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorderFor("ip-range-controller"),
-		NetboxClient:      netboxClient,
-		OperatorNamespace: operatorNamespace,
-		RestConfig:        mgr.GetConfig(),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		EventStatusRecorder: controller.NewEventStatusRecorder(mgr.GetClient(), mgr.GetEventRecorderFor("ip-range-controller")),
+		NetboxClient:        netboxClient,
+		OperatorNamespace:   operatorNamespace,
+		RestConfig:          mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IpRange")
 		os.Exit(1)

--- a/internal/controller/interfaces.go
+++ b/internal/controller/interfaces.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 Swisscom (Schweiz) AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ObjectWithConditions interface {
+	client.Object
+	Conditions() *[]metav1.Condition
+}

--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -33,11 +33,9 @@ import (
 	"github.com/swisscom/leaselocker"
 	corev1 "k8s.io/api/core/v1"
 	apismeta "k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -50,11 +48,11 @@ const IPManagedCustomFieldsAnnotationName = "ipaddress.netbox.dev/managed-custom
 // IpAddressReconciler reconciles a IpAddress object
 type IpAddressReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
-	NetboxClient      *api.NetboxClient
-	Recorder          record.EventRecorder
-	OperatorNamespace string
-	RestConfig        *rest.Config
+	Scheme              *runtime.Scheme
+	NetboxClient        *api.NetboxClient
+	EventStatusRecorder *EventStatusRecorder
+	OperatorNamespace   string
+	RestConfig          *rest.Config
 }
 
 //+kubebuilder:rbac:groups=netbox.dev,resources=ipaddresses,verbs=get;list;watch;create;update;patch;delete
@@ -81,7 +79,7 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if !o.Spec.PreserveInNetbox {
 				err := r.NetboxClient.DeleteIpAddress(o.Status.IpAddressId)
 				if err != nil {
-					setConditionErr := r.SetConditionAndCreateEvent(ctx, o, netboxv1.ConditionIpaddressReadyFalseDeletionFailed, corev1.EventTypeWarning, err.Error())
+					setConditionErr := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalseDeletionFailed, corev1.EventTypeWarning, err)
 					if setConditionErr != nil {
 						return ctrl.Result{}, fmt.Errorf("error updating status: %w, when deleting IPAddress failed: %w", setConditionErr, err)
 					}
@@ -148,7 +146,7 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		locked := ll.TryLock(lockCtx)
 		if !locked {
 			errorMsg := fmt.Sprintf("failed to lock parent prefix %s", ipAddressClaim.Spec.ParentPrefix)
-			r.Recorder.Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
+			r.EventStatusRecorder.rec.Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
 			return ctrl.Result{
 				RequeueAfter: 2 * time.Second,
 			}, nil
@@ -177,8 +175,8 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			logger.Info("restoration hash mismatch, deleting ip address custom resource", "ipaddress", o.Spec.IpAddress)
 			err = r.Client.Delete(ctx, o)
 			if err != nil {
-				if updateStatusErr := r.SetConditionAndCreateEvent(ctx, o, netboxv1.ConditionIpaddressReadyFalse,
-					corev1.EventTypeWarning, err.Error()); updateStatusErr != nil {
+				if updateStatusErr := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalse,
+					corev1.EventTypeWarning, err); updateStatusErr != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update ip address status: %w, "+
 						"after deletion of ip address cr failed: %w", updateStatusErr, err)
 				}
@@ -188,8 +186,8 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		}
 
-		if updateStatusErr := r.SetConditionAndCreateEvent(ctx, o, netboxv1.ConditionIpaddressReadyFalse,
-			corev1.EventTypeWarning, err.Error()); updateStatusErr != nil {
+		if updateStatusErr := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalse,
+			corev1.EventTypeWarning, err, o.Spec.IpAddress); updateStatusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update ip address status: %w, "+
 				"after reservation of ip in netbox failed: %w", updateStatusErr, err)
 		}
@@ -232,12 +230,12 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// check if created ip address contains entire description from spec
 	_, found := strings.CutPrefix(netboxIpAddressModel.Description, req.NamespacedName.String()+" // "+o.Spec.Description)
 	if !found {
-		r.Recorder.Event(o, corev1.EventTypeWarning, "IpDescriptionTruncated", "ip address was created with truncated description")
+		r.EventStatusRecorder.rec.Event(o, corev1.EventTypeWarning, "IpDescriptionTruncated", "ip address was created with truncated description")
 	}
 
 	debugLogger.Info(fmt.Sprintf("reserved ip address in netbox, ip: %s", o.Spec.IpAddress))
 
-	err = r.SetConditionAndCreateEvent(ctx, o, netboxv1.ConditionIpaddressReadyTrue, corev1.EventTypeNormal, "")
+	err = r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyTrue, corev1.EventTypeNormal, nil)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -252,21 +250,6 @@ func (r *IpAddressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&netboxv1.IpAddress{}).
 		Complete(r)
-}
-
-func (r *IpAddressReconciler) SetConditionAndCreateEvent(ctx context.Context, o *netboxv1.IpAddress, condition metav1.Condition, eventType string, conditionMessageAppend string) error {
-	if len(conditionMessageAppend) > 0 {
-		condition.Message = condition.Message + ". " + conditionMessageAppend
-	}
-	conditionChanged := apismeta.SetStatusCondition(&o.Status.Conditions, condition)
-	if conditionChanged {
-		r.Recorder.Event(o, eventType, condition.Reason, condition.Message)
-	}
-	err := r.Client.Status().Update(ctx, o)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func generateNetboxIpAddressModelFromIpAddressSpec(spec *netboxv1.IpAddressSpec, req ctrl.Request, lastIpAddressMetadata string) (*models.IPAddress, error) {

--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -79,11 +79,9 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if !o.Spec.PreserveInNetbox {
 				err := r.NetboxClient.DeleteIpAddress(o.Status.IpAddressId)
 				if err != nil {
-					setConditionErr := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalseDeletionFailed, corev1.EventTypeWarning, err)
-					if setConditionErr != nil {
-						return ctrl.Result{}, fmt.Errorf("error updating status: %w, when deleting IPAddress failed: %w", setConditionErr, err)
+					if errReport := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalseDeletionFailed, corev1.EventTypeWarning, err); errReport != nil {
+						return ctrl.Result{}, errReport
 					}
-
 					return ctrl.Result{Requeue: true}, nil
 				}
 			}
@@ -115,7 +113,7 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Set ready to false initially
 	if apismeta.FindStatusCondition(o.Status.Conditions, netboxv1.ConditionReadyFalseNewResource.Type) == nil {
-		err := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalse, corev1.EventTypeNormal, nil)
+		err := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionReadyFalseNewResource, corev1.EventTypeNormal, nil)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to initialise Ready condition: %w, ", err)
 		}

--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -146,7 +146,7 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		locked := ll.TryLock(lockCtx)
 		if !locked {
 			errorMsg := fmt.Sprintf("failed to lock parent prefix %s", ipAddressClaim.Spec.ParentPrefix)
-			r.EventStatusRecorder.rec.Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
+			r.EventStatusRecorder.Recorder().Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
 			return ctrl.Result{
 				RequeueAfter: 2 * time.Second,
 			}, nil
@@ -230,7 +230,7 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// check if created ip address contains entire description from spec
 	_, found := strings.CutPrefix(netboxIpAddressModel.Description, req.NamespacedName.String()+" // "+o.Spec.Description)
 	if !found {
-		r.EventStatusRecorder.rec.Event(o, corev1.EventTypeWarning, "IpDescriptionTruncated", "ip address was created with truncated description")
+		r.EventStatusRecorder.Recorder().Event(o, corev1.EventTypeWarning, "IpDescriptionTruncated", "ip address was created with truncated description")
 	}
 
 	debugLogger.Info(fmt.Sprintf("reserved ip address in netbox, ip: %s", o.Spec.IpAddress))

--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -113,6 +113,14 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
+	// Set ready to false initially
+	if apismeta.FindStatusCondition(o.Status.Conditions, netboxv1.ConditionReadyFalseNewResource.Type) == nil {
+		err := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalse, corev1.EventTypeNormal, nil)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to initialise Ready condition: %w, ", err)
+		}
+	}
+
 	// 1. try to lock lease of parent prefix if IpAddress status condition is not true
 	// and IpAddress is owned by an IpAddressClaim
 	or := o.ObjectMeta.OwnerReferences

--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -74,6 +74,14 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
+	// Set ready to false initially
+	if apismeta.FindStatusCondition(o.Status.Conditions, netboxv1.ConditionReadyFalseNewResource.Type) == nil {
+		err := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalse, corev1.EventTypeNormal, nil)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to initialise Ready condition: %w, ", err)
+		}
+	}
+
 	// 1. check if matching IpAddress object already exists
 	ipAddress := &netboxv1.IpAddress{}
 	ipAddressName := o.ObjectMeta.Name

--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -109,7 +109,7 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if !locked {
 			// lock for parent prefix was not available, rescheduling
 			errorMsg := fmt.Sprintf("failed to lock parent prefix %s", o.Spec.ParentPrefix)
-			r.EventStatusRecorder.rec.Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
+			r.EventStatusRecorder.Recorder().Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
 			return ctrl.Result{
 				RequeueAfter: 2 * time.Second,
 			}, nil

--- a/internal/controller/iprange_controller.go
+++ b/internal/controller/iprange_controller.go
@@ -166,7 +166,7 @@ func (r *IpRangeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 
 		if err = r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpRangeReadyFalse,
-			corev1.EventTypeWarning, err, fmt.Sprintf("%s-%s ", o.Spec.StartAddress, o.Spec.EndAddress)); err != nil {
+			corev1.EventTypeWarning, err, fmt.Sprintf("range: %s-%s", o.Spec.StartAddress, o.Spec.EndAddress)); err != nil {
 			return ctrl.Result{}, err
 		}
 

--- a/internal/controller/iprange_controller.go
+++ b/internal/controller/iprange_controller.go
@@ -89,6 +89,14 @@ func (r *IpRangeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, removeFinalizer(ctx, r.Client, o, IpRangeFinalizerName)
 	}
 
+	// Set ready to false initially
+	if apismeta.FindStatusCondition(o.Status.Conditions, netboxv1.ConditionReadyFalseNewResource.Type) == nil {
+		err := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalse, corev1.EventTypeNormal, nil)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to initialise Ready condition: %w, ", err)
+		}
+	}
+
 	// if PreserveIpInNetbox flag is false then register finalizer if not yet registered
 	if !o.Spec.PreserveInNetbox {
 		err = addFinalizer(ctx, r.Client, o, IpRangeFinalizerName)

--- a/internal/controller/iprange_controller.go
+++ b/internal/controller/iprange_controller.go
@@ -120,7 +120,7 @@ func (r *IpRangeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		locked := ll.TryLock(lockCtx)
 		if !locked {
 			logger.Info(fmt.Sprintf("failed to lock parent prefix %s", parentPrefix))
-			r.EventStatusRecorder.rec.Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", "failed to lock parent prefix %s",
+			r.EventStatusRecorder.Recorder().Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", "failed to lock parent prefix %s",
 				parentPrefix)
 			return ctrl.Result{Requeue: true}, nil
 		}
@@ -245,7 +245,7 @@ func (r *IpRangeReconciler) generateNetboxIpRangeModelFromIpRangeSpec(o *netboxv
 	// check if created ip range contains entire description from spec
 	_, found := strings.CutPrefix(description, req.NamespacedName.String()+" // "+o.Spec.Description)
 	if !found {
-		r.EventStatusRecorder.rec.Event(o, corev1.EventTypeWarning, "IpRangeDescriptionTruncated", "ip range was created with truncated description")
+		r.EventStatusRecorder.Recorder().Event(o, corev1.EventTypeWarning, "IpRangeDescriptionTruncated", "ip range was created with truncated description")
 	}
 
 	return &models.IpRange{

--- a/internal/controller/iprange_controller.go
+++ b/internal/controller/iprange_controller.go
@@ -91,7 +91,7 @@ func (r *IpRangeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Set ready to false initially
 	if apismeta.FindStatusCondition(o.Status.Conditions, netboxv1.ConditionReadyFalseNewResource.Type) == nil {
-		err := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalse, corev1.EventTypeNormal, nil)
+		err := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionReadyFalseNewResource, corev1.EventTypeNormal, nil)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to initialise Ready condition: %w, ", err)
 		}

--- a/internal/controller/iprangeclaim_controller.go
+++ b/internal/controller/iprangeclaim_controller.go
@@ -94,6 +94,14 @@ func (r *IpRangeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Set ready to false initially
+	if apismeta.FindStatusCondition(o.Status.Conditions, netboxv1.ConditionReadyFalseNewResource.Type) == nil {
+		err := r.EventStatusRecorder.Report(ctx, o, netboxv1.ConditionIpaddressReadyFalse, corev1.EventTypeNormal, nil)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to initialise Ready condition: %w, ", err)
+		}
+	}
+
 	err = r.Client.Get(ctx, ipRangeLookupKey, ipRange)
 	if err != nil {
 		// return error if not a notfound error

--- a/internal/controller/iprangeclaim_controller.go
+++ b/internal/controller/iprangeclaim_controller.go
@@ -212,7 +212,7 @@ func (r *IpRangeClaimReconciler) tryLockOnParentPrefix(ctx context.Context, o *n
 	if !locked {
 		// lock for parent prefix was not available, rescheduling
 		logger.Info(fmt.Sprintf("failed to lock parent prefix %s", o.Spec.ParentPrefix))
-		r.EventStatusRecorder.rec.Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", "failed to lock parent prefix %s",
+		r.EventStatusRecorder.Recorder().Eventf(o, corev1.EventTypeWarning, "FailedToLockParentPrefix", "failed to lock parent prefix %s",
 			o.Spec.ParentPrefix)
 		return nil, ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}

--- a/internal/controller/prefix_controller.go
+++ b/internal/controller/prefix_controller.go
@@ -159,7 +159,7 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// create lock
 			if locked := ll.TryLock(lockCtx); !locked {
 				errorMsg := fmt.Sprintf("failed to lock parent prefix %s", prefixClaim.Status.SelectedParentPrefix)
-				r.EventStatusRecorder.rec.Eventf(prefix, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
+				r.EventStatusRecorder.Recorder().Eventf(prefix, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
 				return ctrl.Result{
 					RequeueAfter: 2 * time.Second,
 				}, nil
@@ -242,7 +242,7 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// check if the created prefix contains the entire description from spec
 	if _, found := strings.CutPrefix(netboxPrefixModel.Description, req.NamespacedName.String()+" // "+prefix.Spec.Description); !found {
-		r.EventStatusRecorder.rec.Event(prefix, corev1.EventTypeWarning, "PrefixDescriptionTruncated", "prefix was created with truncated description")
+		r.EventStatusRecorder.Recorder().Event(prefix, corev1.EventTypeWarning, "PrefixDescriptionTruncated", "prefix was created with truncated description")
 	}
 
 	debugLogger.Info(fmt.Sprintf("reserved prefix in netbox, prefix: %s", prefix.Spec.Prefix))

--- a/internal/controller/prefix_controller.go
+++ b/internal/controller/prefix_controller.go
@@ -30,11 +30,9 @@ import (
 	"github.com/netbox-community/netbox-operator/pkg/netbox/models"
 	corev1 "k8s.io/api/core/v1"
 	apismeta "k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -51,11 +49,11 @@ const PXManagedCustomFieldsAnnotationName = "prefix.netbox.dev/managed-custom-fi
 // PrefixReconciler reconciles a Prefix object
 type PrefixReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
-	NetboxClient      *api.NetboxClient
-	Recorder          record.EventRecorder
-	OperatorNamespace string
-	RestConfig        *rest.Config
+	Scheme              *runtime.Scheme
+	NetboxClient        *api.NetboxClient
+	EventStatusRecorder *EventStatusRecorder
+	OperatorNamespace   string
+	RestConfig          *rest.Config
 }
 
 // +kubebuilder:rbac:groups=netbox.dev,resources=prefixes,verbs=get;list;watch;create;update;patch;delete
@@ -81,7 +79,7 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if controllerutil.ContainsFinalizer(prefix, PrefixFinalizerName) {
 			if !prefix.Spec.PreserveInNetbox {
 				if err := r.NetboxClient.DeletePrefix(prefix.Status.PrefixId); err != nil {
-					setConditionErr := r.SetConditionAndCreateEvent(ctx, prefix, netboxv1.ConditionPrefixReadyFalseDeletionFailed, corev1.EventTypeWarning, err.Error())
+					setConditionErr := r.EventStatusRecorder.Report(ctx, prefix, netboxv1.ConditionPrefixReadyFalseDeletionFailed, corev1.EventTypeWarning, err)
 					if setConditionErr != nil {
 						return ctrl.Result{}, fmt.Errorf("error updating status: %w, when deleting Prefix failed: %w", setConditionErr, err)
 					}
@@ -134,7 +132,7 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		if prefixClaim.Status.SelectedParentPrefix == "" {
 			// the parent prefix is not selected
-			if err := r.SetConditionAndCreateEvent(ctx, prefix, netboxv1.ConditionPrefixReadyFalse, corev1.EventTypeWarning, "the parent prefix is not selected"); err != nil {
+			if err := r.EventStatusRecorder.Report(ctx, prefix, netboxv1.ConditionPrefixReadyFalse, corev1.EventTypeWarning, fmt.Errorf("%s", "the parent prefix is not selected")); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{
@@ -161,7 +159,7 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// create lock
 			if locked := ll.TryLock(lockCtx); !locked {
 				errorMsg := fmt.Sprintf("failed to lock parent prefix %s", prefixClaim.Status.SelectedParentPrefix)
-				r.Recorder.Eventf(prefix, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
+				r.EventStatusRecorder.rec.Eventf(prefix, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
 				return ctrl.Result{
 					RequeueAfter: 2 * time.Second,
 				}, nil
@@ -191,8 +189,8 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			logger.Info("restoration hash mismatch, deleting prefix custom resource", "prefix", prefix.Spec.Prefix)
 			err = r.Client.Delete(ctx, prefix)
 			if err != nil {
-				if updateStatusErr := r.SetConditionAndCreateEvent(ctx, prefix, netboxv1.ConditionPrefixReadyFalse,
-					corev1.EventTypeWarning, err.Error()); updateStatusErr != nil {
+				if updateStatusErr := r.EventStatusRecorder.Report(ctx, prefix, netboxv1.ConditionPrefixReadyFalse,
+					corev1.EventTypeWarning, err); updateStatusErr != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update prefix status: %w, "+
 						"after deletion of prefix cr failed: %w", updateStatusErr, err)
 				}
@@ -201,8 +199,8 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, nil
 		}
 
-		if updateStatusErr := r.SetConditionAndCreateEvent(ctx, prefix, netboxv1.ConditionPrefixReadyFalse,
-			corev1.EventTypeWarning, err.Error()); updateStatusErr != nil {
+		if updateStatusErr := r.EventStatusRecorder.Report(ctx, prefix, netboxv1.ConditionPrefixReadyFalse,
+			corev1.EventTypeWarning, err); updateStatusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update prefix status: %w, "+
 				"after reservation of prefix netbox failed: %w", updateStatusErr, err)
 		}
@@ -244,11 +242,11 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// check if the created prefix contains the entire description from spec
 	if _, found := strings.CutPrefix(netboxPrefixModel.Description, req.NamespacedName.String()+" // "+prefix.Spec.Description); !found {
-		r.Recorder.Event(prefix, corev1.EventTypeWarning, "PrefixDescriptionTruncated", "prefix was created with truncated description")
+		r.EventStatusRecorder.rec.Event(prefix, corev1.EventTypeWarning, "PrefixDescriptionTruncated", "prefix was created with truncated description")
 	}
 
 	debugLogger.Info(fmt.Sprintf("reserved prefix in netbox, prefix: %s", prefix.Spec.Prefix))
-	if err = r.SetConditionAndCreateEvent(ctx, prefix, netboxv1.ConditionPrefixReadyTrue, corev1.EventTypeNormal, ""); err != nil {
+	if err = r.EventStatusRecorder.Report(ctx, prefix, netboxv1.ConditionPrefixReadyTrue, corev1.EventTypeNormal, nil); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -262,22 +260,6 @@ func (r *PrefixReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&netboxv1.Prefix{}).
 		Complete(r)
-}
-
-// TODO(henrybear327): Duplicated code, consider refactoring this
-func (r *PrefixReconciler) SetConditionAndCreateEvent(ctx context.Context, o *netboxv1.Prefix, condition metav1.Condition, eventType string, conditionMessageAppend string) error {
-	if len(conditionMessageAppend) > 0 {
-		condition.Message = condition.Message + ". " + conditionMessageAppend
-	}
-	conditionChanged := apismeta.SetStatusCondition(&o.Status.Conditions, condition)
-	if conditionChanged {
-		r.Recorder.Event(o, eventType, condition.Reason, condition.Message)
-	}
-	err := r.Client.Status().Update(ctx, o)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func generateNetboxPrefixModelFromPrefixSpec(spec *netboxv1.PrefixSpec, req ctrl.Request, lastPrefixMetadata string) (*models.Prefix, error) {

--- a/internal/controller/prefix_controller.go
+++ b/internal/controller/prefix_controller.go
@@ -102,6 +102,14 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
+	// Set ready to false initially
+	if apismeta.FindStatusCondition(prefix.Status.Conditions, netboxv1.ConditionReadyFalseNewResource.Type) == nil {
+		err := r.EventStatusRecorder.Report(ctx, prefix, netboxv1.ConditionIpaddressReadyFalse, corev1.EventTypeNormal, nil)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to initialise Ready condition: %w, ", err)
+		}
+	}
+
 	// register finalizer if not yet registered
 	if !prefix.Spec.PreserveInNetbox && !controllerutil.ContainsFinalizer(prefix, PrefixFinalizerName) {
 		debugLogger.Info("adding the finalizer")

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -210,7 +210,7 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if !locked {
 				// lock for parent prefix was not available, rescheduling
 				errorMsg := fmt.Sprintf("failed to lock parent prefix %s", prefixClaim.Status.SelectedParentPrefix)
-				r.EventStatusRecorder.rec.Eventf(prefixClaim, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
+				r.EventStatusRecorder.Recorder().Eventf(prefixClaim, corev1.EventTypeWarning, "FailedToLockParentPrefix", errorMsg)
 				return ctrl.Result{
 					RequeueAfter: 2 * time.Second,
 				}, nil

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -78,6 +78,14 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
+	// Set ready to false initially
+	if apismeta.FindStatusCondition(prefixClaim.Status.Conditions, netboxv1.ConditionReadyFalseNewResource.Type) == nil {
+		err := r.EventStatusRecorder.Report(ctx, prefixClaim, netboxv1.ConditionIpaddressReadyFalse, corev1.EventTypeNormal, nil)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to initialise Ready condition: %w, ", err)
+		}
+	}
+
 	/* 1. compute and assign the parent prefix if required */
 	// The current design will use prefixClaim.Status.ParentPrefix for storing the selected parent prefix,
 	// and as the source of truth for future parent prefix references

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -156,7 +156,7 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				// fetch available prefixes from netbox
 				parentPrefixCandidates, err := r.NetboxClient.GetAvailablePrefixByParentPrefixSelector(&prefixClaim.Spec)
 				if err != nil || len(parentPrefixCandidates) == 0 {
-					if errReport := r.EventStatusRecorder.Report(ctx, prefixClaim, netboxv1.ConditionParentPrefixSelectedFalse, corev1.EventTypeWarning, fmt.Errorf("no parent prefix can be obtained with the query conditions set in ParentPrefixSelector, err = %v, number of candidates = %v", err, len(parentPrefixCandidates))); errReport != nil {
+					if errReport := r.EventStatusRecorder.Report(ctx, prefixClaim, netboxv1.ConditionParentPrefixSelectedFalse, corev1.EventTypeWarning, fmt.Errorf("no parent prefix can be obtained with the query conditions set in ParentPrefixSelector, err = %w, number of candidates = %v", err, len(parentPrefixCandidates))); errReport != nil {
 						return ctrl.Result{}, errReport
 					}
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -118,9 +118,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&IpAddressReconciler{
-		Client:   k8sManager.GetClient(),
-		Scheme:   k8sManager.GetScheme(),
-		Recorder: k8sManager.GetEventRecorderFor("ip-address-claim-controller"),
+		Client:              k8sManager.GetClient(),
+		Scheme:              k8sManager.GetScheme(),
+		EventStatusRecorder: NewEventStatusRecorder(k8sManager.GetClient(), k8sManager.GetEventRecorderFor("ip-address-controller")),
 		NetboxClient: &api.NetboxClient{
 			Ipam:    ipamMockIpAddress,
 			Tenancy: tenancyMock,
@@ -132,9 +132,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&IpAddressClaimReconciler{
-		Client:   k8sManager.GetClient(),
-		Scheme:   k8sManager.GetScheme(),
-		Recorder: k8sManager.GetEventRecorderFor("ip-address-claim-controller"),
+		Client:              k8sManager.GetClient(),
+		Scheme:              k8sManager.GetScheme(),
+		EventStatusRecorder: NewEventStatusRecorder(k8sManager.GetClient(), k8sManager.GetEventRecorderFor("ip-address-claim-controller")),
 		NetboxClient: &api.NetboxClient{
 			Ipam:    ipamMockIpAddressClaim,
 			Tenancy: tenancyMock,

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -89,7 +89,7 @@ func (esr *EventStatusRecorder) Report(ctx context.Context, o ObjectWithConditio
 	logger := log.FromContext(ctx)
 
 	if errExt != nil {
-		condition.Message = condition.Message + ", " + errExt.Error()
+		condition.Message = condition.Message + ": " + errExt.Error()
 		logger.Error(errExt, condition.Message)
 	}
 

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -109,3 +109,7 @@ func (esr *EventStatusRecorder) Report(ctx context.Context, o ObjectWithConditio
 
 	return nil
 }
+
+func (esr *EventStatusRecorder) Recorder() record.EventRecorder {
+	return esr.rec
+}

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/chainsaw-test.yaml
@@ -45,7 +45,7 @@ spec:
               reason: ParentPrefixNotSelected
               source:
                 component: prefix-claim-controller
-              message: "The parent prefix was not able to be selected. no parent prefix can be obtained with the query conditions set in ParentPrefixSelector, err = failed to fetch tenant 'niltenant': not found, number of candidates = 0"
+              message: "The parent prefix was not able to be selected: no parent prefix can be obtained with the query conditions set in ParentPrefixSelector, err = failed to fetch tenant 'niltenant': not found, number of candidates = 0"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: PrefixClaim

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -94,7 +94,7 @@ spec:
               reason: PrefixCRNotCreated
               source:
                 component: prefix-claim-controller
-              message: Failed to fetch new Prefix from NetBox. parent prefix exhausted, will restart the parent prefix selection process
+              message: "Failed to fetch new Prefix from NetBox: parent prefix exhausted, will restart the parent prefix selection process"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: PrefixClaim

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -129,7 +129,7 @@ spec:
               reason: IPAddressCRNotCreated
               source:
                 component: ip-address-claim-controller
-              message: Failed to fetch new IP from NetBox. parent prefix exhausted
+              message: "Failed to fetch new IP from NetBox: parent prefix exhausted"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpAddressClaim

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -129,7 +129,7 @@ spec:
               reason: IPAddressCRNotCreated
               source:
                 component: ip-address-claim-controller
-              message: Failed to fetch new IP from NetBox. parent prefix exhausted
+              message: "Failed to fetch new IP from NetBox: parent prefix exhausted"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpAddressClaim

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldnotexisting/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldnotexisting/chainsaw-test.yaml
@@ -55,7 +55,7 @@ spec:
               reason: FailedToReserveIPRangeInNetbox
               source:
                 component: ip-range-controller
-              message: Failed to reserve IP Range in NetBox. 3.2.3.1/32-3.2.3.30/32 . Check the logs for more information.
+              message: "Failed to reserve IP Range in NetBox: failed to reserve IP Range: [POST /ipam/ip-ranges/][400] ipam_ip-ranges_create default  map[__all__:[Unknown field name 'justmade' in custom field data.]], range: 3.2.3.1/32-3.2.3.30/32"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpRange

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldwrongdatatype/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldwrongdatatype/chainsaw-test.yaml
@@ -55,7 +55,7 @@ spec:
               reason: FailedToReserveIPRangeInNetbox
               source:
                 component: ip-range-controller
-              message: Failed to reserve IP Range in NetBox. 3.2.3.1/32-3.2.3.30/32 . Check the logs for more information.
+              message: "Failed to reserve IP Range in NetBox: failed to reserve IP Range: [POST /ipam/ip-ranges/][400] ipam_ip-ranges_create default  map[__all__:[Unknown field name 'cfDataTypeInteger' in custom field data.]], range: 3.2.3.1/32-3.2.3.30/32"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpRange

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
               reason: IPRangeCRNotCreated
               source:
                 component: ip-range-claim-controller
-              message: Failed to fetch new IP Range from NetBox. Check the logs for more information.
+              message: "Failed to fetch new IP Range from NetBox: failed to fetch parent prefix: not found"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpRangeClaim

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/chainsaw-test.yaml
@@ -36,7 +36,7 @@ spec:
               reason: IPRangeCRNotCreated
               source:
                 component: ip-range-claim-controller
-              message: Failed to fetch new IP Range from NetBox. Check the logs for more information.
+              message: "Failed to fetch new IP Range from NetBox: failed to fetch tenant 'nonexistingtenant': not found"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpRangeClaim

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -138,7 +138,7 @@ spec:
               reason: IPRangeCRNotCreated
               source:
                 component: ip-range-claim-controller
-              message: Failed to fetch new IP Range from NetBox. Check the logs for more information.
+              message: "Failed to fetch new IP Range from NetBox: not enough consecutive IPs available"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpRangeClaim

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -139,7 +139,7 @@ spec:
               reason: IPRangeCRNotCreated
               source:
                 component: ip-range-claim-controller
-              message: Failed to fetch new IP Range from NetBox. Check the logs for more information.
+              message: "Failed to fetch new IP Range from NetBox: not enough consecutive IPs available"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpRangeClaim


### PR DESCRIPTION
This PR shows one way in which we can consolidate the reporting of status and conditions into a common function.

It exposes access to the EventRecorder so events can be emitted independently of condition updates, and also logs changes in conditions as well as errors.

Would be happy to receive feedback and take suggestions as to how we can improve this functionality.