### PR TITLE
Feature/check keys in parent prefix selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,24 +239,24 @@ generate_mocks: ## TODO: auto install go install go.uber.org/mock/mockgen@latest
 	mockgen -destination ${GEN_DIR}/${NETBOX_MOCKS_OUTPUT_FILE} -source=${INTERFACE_DEFITIONS_DIR}
 
 # e2e tests
-E2E_PARAM := --namespace e2e --parallel 3 --apply-timeout 3m --assert-timeout 3m --delete-timeout 3m --error-timeout 3m --exec-timeout 3m # --skip-delete (add this argument for local debugging)
+E2E_PARAM := --namespace e2e --parallel 3 --apply-timeout 3m --assert-timeout 3m --delete-timeout 3m --error-timeout 3m --exec-timeout 3m --cleanup-timeout 3m # --skip-delete (add this argument for local debugging)
 .PHONY: create-kind-3.7.8
 create-kind-3.7.8:
 	./kind/local-env.sh --version 3.7.8
 .PHONY: test-e2e-3.7.8
-test-e2e-3.7.8: create-kind-3.7.8 deploy-kind install-$(GO_PACKAGE_NAME_CHAINSAW) 
+test-e2e-3.7.8: create-kind-3.7.8 deploy-kind install-$(GO_PACKAGE_NAME_CHAINSAW)
 	chainsaw test $(E2E_PARAM)
 
 .PHONY: create-kind-4.0.11
 create-kind-4.0.11:
 	./kind/local-env.sh --version 4.0.11
 .PHONY: test-e2e-4.0.11
-test-e2e-4.0.11: create-kind-4.0.11 deploy-kind install-$(GO_PACKAGE_NAME_CHAINSAW) 
+test-e2e-4.0.11: create-kind-4.0.11 deploy-kind install-$(GO_PACKAGE_NAME_CHAINSAW)
 	chainsaw test $(E2E_PARAM)
 
 .PHONY: create-kind-4.1.8
 create-kind-4.1.8:
 	./kind/local-env.sh --version 4.1.8
 .PHONY: test-e2e-4.1.8
-test-e2e-4.1.8: create-kind-4.1.8 deploy-kind install-$(GO_PACKAGE_NAME_CHAINSAW) 
+test-e2e-4.1.8: create-kind-4.1.8 deploy-kind install-$(GO_PACKAGE_NAME_CHAINSAW)
 	chainsaw test $(E2E_PARAM)

--- a/api/v1/prefixclaim_types.go
+++ b/api/v1/prefixclaim_types.go
@@ -174,7 +174,7 @@ var ConditionPrefixAssignedFalse = metav1.Condition{
 	Type:    "PrefixAssigned",
 	Status:  "False",
 	Reason:  "PrefixCRNotCreated",
-	Message: "Failed to fetch new Prefix from NetBox",
+	Message: "Failed to assign prefix, prefix CR creation skipped",
 }
 
 var ConditionParentPrefixSelectedTrue = metav1.Condition{

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -156,7 +156,7 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				// fetch available prefixes from netbox
 				parentPrefixCandidates, err := r.NetboxClient.GetAvailablePrefixesByParentPrefixSelector(&prefixClaim.Spec)
 				if err != nil || len(parentPrefixCandidates) == 0 {
-					r.EventStatusRecorder.Recorder().Event(prefixClaim, corev1.EventTypeWarning, netboxv1.ConditionPrefixAssignedFalse.Reason, err.Error())
+					r.EventStatusRecorder.Recorder().Event(prefixClaim, corev1.EventTypeWarning, netboxv1.ConditionPrefixAssignedFalse.Reason, netboxv1.ConditionPrefixAssignedFalse.Message+": "+err.Error())
 					if err := r.EventStatusRecorder.Report(ctx, prefixClaim, netboxv1.ConditionPrefixAssignedFalse, corev1.EventTypeWarning, err); err != nil {
 						return ctrl.Result{}, err
 					}

--- a/pkg/netbox/api/prefix_claim.go
+++ b/pkg/netbox/api/prefix_claim.go
@@ -195,7 +195,6 @@ func (r *NetboxClient) customFieldsExistsOrErr(customfieldFilterEntries []Custom
 
 	missingCustomFields := make([]string, 0)
 	for _, entry := range customfieldFilterEntries {
-		//request to netbox to check if the custom field existse
 		if !slices.Contains(customFieldNames, entry.key) {
 			missingCustomFields = append(missingCustomFields, entry.key)
 		}
@@ -203,8 +202,8 @@ func (r *NetboxClient) customFieldsExistsOrErr(customfieldFilterEntries []Custom
 
 	if len(missingCustomFields) > 0 {
 		return fmt.Errorf(
-		    "invalid parentPrefixSelector, netbox custom fields %s do not exist",
-		    strings.Join(missingCustomFields, ", "),
+			"invalid parentPrefixSelector, netbox custom fields %s do not exist",
+			strings.Join(missingCustomFields, ", "),
 		)
 	}
 

--- a/pkg/netbox/api/prefix_claim.go
+++ b/pkg/netbox/api/prefix_claim.go
@@ -202,7 +202,10 @@ func (r *NetboxClient) customFieldsExistsOrErr(customfieldFilterEntries []Custom
 	}
 
 	if len(missingCustomFields) > 0 {
-		return fmt.Errorf("invalid parentPrefixSelector, netbox custom fields %v do not exist", missingCustomFields)
+		return fmt.Errorf(
+		    "invalid parentPrefixSelector, netbox custom fields %s do not exist",
+		    strings.Join(missingCustomFields, ", "),
+		)
 	}
 
 	return nil

--- a/pkg/netbox/api/prefix_claim.go
+++ b/pkg/netbox/api/prefix_claim.go
@@ -94,7 +94,7 @@ func validatePrefixLengthOrError(prefixClaim *models.PrefixClaim, prefixFamily i
 	return nil
 }
 
-func (r *NetboxClient) GetAvailablePrefixByParentPrefixSelector(prefixClaimSpec *netboxv1.PrefixClaimSpec) ([]*models.Prefix, error) {
+func (r *NetboxClient) GetAvailablePrefixesByParentPrefixSelector(prefixClaimSpec *netboxv1.PrefixClaimSpec) ([]*models.Prefix, error) {
 	fieldEntries := make(map[string]string)
 
 	if tenant, ok := prefixClaimSpec.ParentPrefixSelector["tenant"]; ok {
@@ -130,7 +130,7 @@ func (r *NetboxClient) GetAvailablePrefixByParentPrefixSelector(prefixClaimSpec 
 	for k, v := range prefixClaimSpec.ParentPrefixSelector {
 		switch k {
 		case "tenant", "site", "family":
-			// already handled
+			// skip built in fields
 		default:
 			parentPrefixSelectorCustomFields = append(parentPrefixSelectorCustomFields, CustomFieldEntry{
 				key:   k,
@@ -181,7 +181,7 @@ func (r *NetboxClient) customFieldsExistsOrErr(customfieldFilterEntries []Custom
 	}
 
 	existingCustomFields := responseGetCustomFieldsList.Payload.Results
-	if existingCustomFields == nil || len(existingCustomFields) == 0 {
+	if len(existingCustomFields) == 0 {
 		return fmt.Errorf("netbox custom fields list is nil or empty")
 	}
 

--- a/pkg/netbox/api/prefix_claim_test.go
+++ b/pkg/netbox/api/prefix_claim_test.go
@@ -1257,5 +1257,5 @@ func TestPrefixClaim_GetAvailablePrefixByParentPrefixSelectorFailIfNonExistingFi
 	actual, err := netboxClient.GetAvailablePrefixesByParentPrefixSelector(&pxcSpec)
 
 	assert.Nil(t, actual)
-	AssertError(t, err, "invalid parentPrefixSelector, netbox custom fields [non-existing] do not exist")
+	AssertError(t, err, "invalid parentPrefixSelector, netbox custom fields non-existing do not exist")
 }

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/chainsaw-test.yaml
@@ -34,19 +34,27 @@ spec:
                   environment: "nilenv"
                   poolName: "nilpool"
               status:
-                (conditions[?type == 'ParentPrefixSelected']):
+                (conditions[?type == 'PrefixAssigned']):
                   - status: 'False'
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
-              reason: ParentPrefixNotSelected
+              reason: PrefixCRNotCreated
               source:
                 component: prefix-claim-controller
-              message: "The parent prefix was not able to be selected: no parent prefix can be obtained with the query conditions set in ParentPrefixSelector, err = failed to fetch tenant 'niltenant': not found, number of candidates = 0"
+              message: "Failed to assign prefix, prefix CR creation skipped: failed to fetch tenant 'niltenant': not found"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: PrefixClaim
                 name: prefixclaim-ipv4-invalid-parentprefixselector
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-invalid-parentprefixselector -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/chainsaw-test.yaml
@@ -53,8 +53,5 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-invalid-parentprefixselector -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/chainsaw-test.yaml
@@ -83,8 +83,5 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-apply-update -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/chainsaw-test.yaml
@@ -79,3 +79,12 @@ spec:
                 prefix: 2.0.2.0/28
                 site: MY_SITE
                 tenant: MY_TENANT
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-apply-update -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/chainsaw-test.yaml
@@ -130,13 +130,10 @@ spec:
                 tenant: MY_TENANT
                 customFields:
                   netboxOperatorRestorationHash: 00b8772de73cdac083b0732d5bb85ab4f0caa16c
-    - name: Cleanup events
-      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+    - name: Cleanup events and leases
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-restore-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-restore-2 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/chainsaw-test.yaml
@@ -130,8 +130,8 @@ spec:
                 tenant: MY_TENANT
                 customFields:
                   netboxOperatorRestorationHash: 00b8772de73cdac083b0732d5bb85ab4f0caa16c
-    - name: Cleanup events and leases
-      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
             content: |

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/chainsaw-test.yaml
@@ -130,3 +130,13 @@ spec:
                 tenant: MY_TENANT
                 customFields:
                   netboxOperatorRestorationHash: 00b8772de73cdac083b0732d5bb85ab4f0caa16c
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-restore-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-restore-2 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield
+  annotations:
+    description: Tests if creation fails for parentPrefixSelector with non exising custom field
+spec:
+  steps:
+    - name: Apply CR
+      try:
+        - apply:
+            file: netbox_v1_prefixclaim.yaml
+    - name: Check CR spec
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield
+              spec:
+                comments: your comments
+                description: some description
+                parentPrefixSelector: # The keys and values are case-sensitive
+                  tenant: "MY_TENANT"
+                  site: "MY_SITE"
+                  family: "IPv4"
+                  environment: "Production"
+                  poolName: "Pool 1"
+                  nonexisingfield: "value"
+                prefixLength: /31
+                preserveInNetbox: false
+                site: MY_SITE_2
+                tenant: MY_TENANT_2
+    - name: Check CR status
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield
+              status:
+                (conditions[?type == 'PrefixAssigned']):
+                  - status: 'False'
+                    reason: 'PrefixCRNotCreated'

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
               reason: PrefixCRNotCreated
               source:
                 component: prefix-claim-controller
-              message: "Failed to assign prefix, prefix CR creation skipped: invalid parentPrefixSelector, netbox custom fields [nonexisingfield] do not exist"
+              message: "Failed to assign prefix, prefix CR creation skipped: invalid parentPrefixSelector, netbox custom fields nonexisingfield do not exist"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: PrefixClaim

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
@@ -62,8 +62,5 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
@@ -45,3 +45,17 @@ spec:
                 (conditions[?type == 'PrefixAssigned']):
                   - status: 'False'
                     reason: 'PrefixCRNotCreated'
+        - assert:
+            resource:
+              apiVersion: v1
+              count: 1
+              kind: Event
+              type: Warning
+              reason: PrefixCRNotCreated
+              source:
+                component: prefix-claim-controller
+              message: "Failed to assign prefix, prefix CR creation skipped: invalid parentPrefixSelector, netbox custom fields [nonexisingfield] do not exist"
+              involvedObject:
+                apiVersion: netbox.dev/v1
+                kind: PrefixClaim
+                name: prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
@@ -48,7 +48,6 @@ spec:
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
               reason: PrefixCRNotCreated
@@ -59,3 +58,12 @@ spec:
                 apiVersion: netbox.dev/v1
                 kind: PrefixClaim
                 name: prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/netbox_v1_prefixclaim.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/netbox_v1_prefixclaim.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: netbox.dev/v1
+kind: PrefixClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: netbox-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield
+spec:
+  tenant: "MY_TENANT_2" # Use the `name` value instead of the `slug` value
+  site: "MY_SITE_2" # Use the `name` value instead of the `slug` value
+  description: "some description"
+  comments: "your comments"
+  preserveInNetbox: false
+  prefixLength: "/31"
+  parentPrefixSelector: # The keys and values are case-sensitive
+    tenant: "MY_TENANT" # Use the `name` value instead of the `slug` value
+    site: "MY_SITE" # Use the `name` value instead of the `slug` value
+    family: "IPv4" # Can only be either IPv4 or IPv6"
+    # custom fields of your interest
+    environment: "Production"
+    poolName: "Pool 1"
+    nonexisingfield: "value"

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/chainsaw-test.yaml
@@ -147,9 +147,6 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-restore-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-restore-2 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/chainsaw-test.yaml
@@ -102,7 +102,7 @@ spec:
     - name: Apply CR 1 for the second time again
       try:
         - apply:
-            file: netbox_v1_prefixclaim_1.yaml      
+            file: netbox_v1_prefixclaim_1.yaml
     - name: Check CR 1 spec and status and make sure it is restored
       try:
         - assert:
@@ -143,3 +143,13 @@ spec:
                 tenant: MY_TENANT_2
                 customFields:
                   netboxOperatorRestorationHash: 8a5e15cd391ec02a7a2b2e316bc163f4fe46ef0b
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-restore-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-restore-2 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector/chainsaw-test.yaml
@@ -54,8 +54,5 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-apply -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector/chainsaw-test.yaml
@@ -50,3 +50,12 @@ spec:
                 tenant: MY_TENANT_2
                 customFields:
                   netboxOperatorRestorationHash: 46116345cc81820fdb412dc83e7147d4b1dc1afa
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-apply -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -88,7 +88,6 @@ spec:
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
               reason: PrefixCRNotCreated
@@ -99,3 +98,14 @@ spec:
                 apiVersion: netbox.dev/v1
                 kind: PrefixClaim
                 name: prefixclaim-ipv4-prefixexhausted-3
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -94,7 +94,7 @@ spec:
               reason: PrefixCRNotCreated
               source:
                 component: prefix-claim-controller
-              message: "Failed to fetch new Prefix from NetBox: parent prefix exhausted, will restart the parent prefix selection process"
+              message: "Failed to assign prefix, prefix CR creation skipped: parent prefix exhausted, will restart the parent prefix selection process"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: PrefixClaim

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -102,9 +102,6 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-2 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv6/prefixclaim-ipv6-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv6/prefixclaim-ipv6-apply-update/chainsaw-test.yaml
@@ -90,8 +90,5 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv6-apply-update -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv6/prefixclaim-ipv6-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv6/prefixclaim-ipv6-apply-update/chainsaw-test.yaml
@@ -86,3 +86,12 @@ spec:
                 prefix: 2::/124
                 preserveInNetbox: true
                 tenant: MY_TENANT_2
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv6-apply-update -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/chainsaw-test.yaml
@@ -111,8 +111,5 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-apply-update -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/chainsaw-test.yaml
@@ -107,3 +107,12 @@ spec:
               status:
                 (conditions[?type == 'Ready']):
                   - status: 'True'
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-apply-update -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -137,9 +137,6 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -123,14 +123,24 @@ spec:
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
               reason: IPAddressCRNotCreated
               source:
                 component: ip-address-claim-controller
-              message: "Failed to assign prefix, prefix CR creation skipped: parent prefix exhausted"
+              message: "Failed to fetch new IP from NetBox: parent prefix exhausted"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpAddressClaim
                 name: ipaddressclaim-ipv4-prefixexhausted-3
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -129,7 +129,7 @@ spec:
               reason: IPAddressCRNotCreated
               source:
                 component: ip-address-claim-controller
-              message: "Failed to fetch new IP from NetBox: parent prefix exhausted"
+              message: "Failed to assign prefix, prefix CR creation skipped: parent prefix exhausted"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpAddressClaim

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/chainsaw-test.yaml
@@ -155,3 +155,13 @@ spec:
               status:
                 (conditions[?type == 'Ready']):
                   - status: 'True'
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-restore-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-restore-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/chainsaw-test.yaml
@@ -159,9 +159,6 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-restore-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-restore-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/chainsaw-test.yaml
@@ -111,8 +111,5 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-apply-update -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/chainsaw-test.yaml
@@ -107,3 +107,12 @@ spec:
               status:
                 (conditions[?type == 'Ready']):
                   - status: 'True'
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-apply-update -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -123,14 +123,24 @@ spec:
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
               reason: IPAddressCRNotCreated
               source:
                 component: ip-address-claim-controller
-              message: "Failed to assign prefix, prefix CR creation skipped: parent prefix exhausted"
+              message: "Failed to fetch new IP from NetBox: parent prefix exhausted"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpAddressClaim
                 name: ipaddressclaim-ipv6-prefixexhausted-3
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-2 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -134,7 +134,7 @@ spec:
                 kind: IpAddressClaim
                 name: ipaddressclaim-ipv6-prefixexhausted-3
     - name: Cleanup events
-      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
             content: |

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -129,7 +129,7 @@ spec:
               reason: IPAddressCRNotCreated
               source:
                 component: ip-address-claim-controller
-              message: "Failed to fetch new IP from NetBox: parent prefix exhausted"
+              message: "Failed to assign prefix, prefix CR creation skipped: parent prefix exhausted"
               involvedObject:
                 apiVersion: netbox.dev/v1
                 kind: IpAddressClaim

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -137,9 +137,6 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/chainsaw-test.yaml
@@ -155,3 +155,13 @@ spec:
               status:
                 (conditions[?type == 'Ready']):
                   - status: 'True'
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-restore-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-restore-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/chainsaw-test.yaml
@@ -159,9 +159,6 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-restore-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-restore-2 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-apply-update/chainsaw-test.yaml
@@ -121,9 +121,9 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox)  # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-apply-update -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-cidr/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-cidr/chainsaw-test.yaml
@@ -18,9 +18,9 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-cidr -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldnotexisting/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldnotexisting/chainsaw-test.yaml
@@ -64,9 +64,9 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-customfieldnotexisting -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldwrongdatatype/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldwrongdatatype/chainsaw-test.yaml
@@ -64,9 +64,9 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-customfieldwrongdatatype -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/chainsaw-test.yaml
@@ -38,9 +38,9 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-parentprefix -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/chainsaw-test.yaml
@@ -24,7 +24,6 @@ spec:
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
               reason: IPRangeCRNotCreated

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-size/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-size/chainsaw-test.yaml
@@ -18,9 +18,9 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-size -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/chainsaw-test.yaml
@@ -30,7 +30,6 @@ spec:
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
               reason: IPRangeCRNotCreated

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/chainsaw-test.yaml
@@ -44,9 +44,9 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-tenant -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -132,7 +132,6 @@ spec:
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
               reason: IPRangeCRNotCreated

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -146,11 +146,11 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-restore/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-restore/chainsaw-test.yaml
@@ -176,10 +176,10 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-restore-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-restore-2 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-apply-update/chainsaw-test.yaml
@@ -121,9 +121,9 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-apply-update -n $NAMESPACE

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -133,7 +133,6 @@ spec:
         - assert:
             resource:
               apiVersion: v1
-              count: 1
               kind: Event
               type: Warning
               reason: IPRangeCRNotCreated

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -147,11 +147,11 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-2 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-restore/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-restore/chainsaw-test.yaml
@@ -176,10 +176,10 @@ spec:
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
             content: |
-                kubectl -n netbox-operator-system get lease -oname | grep -v netbox | xargs -n1 kubectl -n netbox-operator-system delete  # to be enhanced in usage of leaselocker
+                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+                if [ -n "$LEASES" ]; then
+                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+                fi
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-restore-1 -n $NAMESPACE
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-restore-2 -n $NAMESPACE


### PR DESCRIPTION
With this feature a check is added to only allow existing fields in the parentPrefixSelector.
If the parent prefix selector contains a key for a custom field that does not exist in NetBox, the key is ignored in the filter.