### PR TITLE
Add step to e2e tests to clean up resources in the test NetBox instance

### DIFF
--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/chainsaw-test.yaml
@@ -155,6 +155,27 @@ spec:
               status:
                 (conditions[?type == 'Ready']):
                   - status: 'True'
+    - name: Set preserveInNetbox to false
+      description: Set preserveInNetbox to false to clean up the NetBox test instance
+      try:
+      - patch:
+          resource:
+            apiVersion: netbox.dev/v1
+            kind: IpAddressClaim
+            metadata:
+              name: ipaddressclaim-ipv4-restore-1
+            spec:
+              preserveInNetbox: false
+      - assert:
+          resource:
+            apiVersion: netbox.dev/v1
+            kind: IpAddressClaim
+            metadata:
+              name: ipaddressclaim-ipv4-restore-1
+            status:
+              (conditions[?type == 'Ready']):
+              - observedGeneration: 2
+                status: 'True'
     - name: Cleanup events
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:


### PR DESCRIPTION
part of https://github.com/netbox-community/netbox-operator/issues/250

The added step sets the preserveInNetbox field to false and waits until the child resources have status condition 'Ready' true  with the expected observedGeneration. 