### PR TITLE
Cleanup old ReplicaSets after NetBox deployment patch to prevent volume Multi-Attach errors

### DIFF
--- a/kind/deploy-netbox.sh
+++ b/kind/deploy-netbox.sh
@@ -259,8 +259,8 @@ if [[ "$FORCE_NETBOX_NGINX_IPV4" == "true" ]]; then
   ' | xargs -r -I{} ${KUBECTL} delete rs {} -n "$NAMESPACE"
 
   echo "Forcing restart of netbox pod to reattach volume cleanly..."
-  ${KUBECTL} get pods -n "$NAMESPACE" -l app.kubernetes.io/component=netbox \
-    -o name | xargs -r ${KUBECTL} delete -n "$NAMESPACE" --grace-period=0 --force
+  ${KUBECTL} delete pods -n "$NAMESPACE" -l app.kubernetes.io/component=netbox \
+      --grace-period=0 --force
 fi
 
 ${KUBECTL} rollout status --namespace="${NAMESPACE}" deployment netbox

--- a/kind/deploy-netbox.sh
+++ b/kind/deploy-netbox.sh
@@ -257,6 +257,10 @@ if [[ "$FORCE_NETBOX_NGINX_IPV4" == "true" ]]; then
       ))
     | .[].metadata.name
   ' | xargs -r -I{} ${KUBECTL} delete rs {} -n "$NAMESPACE"
+
+  echo "Forcing restart of netbox pod to reattach volume cleanly..."
+  ${KUBECTL} get pods -n "$NAMESPACE" -l app.kubernetes.io/component=netbox \
+    -o name | xargs -r ${KUBECTL} delete -n "$NAMESPACE" --grace-period=0 --force
 fi
 
 ${KUBECTL} rollout status --namespace="${NAMESPACE}" deployment netbox

--- a/kind/deploy-netbox.sh
+++ b/kind/deploy-netbox.sh
@@ -257,10 +257,6 @@ if [[ "$FORCE_NETBOX_NGINX_IPV4" == "true" ]]; then
       ))
     | .[].metadata.name
   ' | xargs -r -I{} ${KUBECTL} delete rs {} -n "$NAMESPACE"
-
-  echo "Forcing restart of netbox pod to reattach volume cleanly..."
-  ${KUBECTL} get pods -n "$NAMESPACE" -l app.kubernetes.io/component=netbox \
-    -o name | xargs -r ${KUBECTL} delete -n "$NAMESPACE" --grace-period=0 --force
 fi
 
 ${KUBECTL} rollout status --namespace="${NAMESPACE}" deployment netbox

--- a/kind/deploy-netbox.sh
+++ b/kind/deploy-netbox.sh
@@ -286,10 +286,10 @@ NETBOX_API_URL="http://netbox.${NAMESPACE}.svc.cluster.local"
 PATCHED_TMP_JOB_YAML="$(mktemp)"
 
 # Convert YAML to JSON and inject variables if containers exist
-yq -o=json "$TMP_JOB_YAML" | jq \
+yq r -j "$TMP_JOB_YAML" | jq \
   --arg netboxApi "$NETBOX_API_URL" \
-  --arg pypiUrl "$PYPI_REPOSITORY_URL" \
-  --arg artifactoryHost "$ARTIFACTORY_TRUSTED_HOST" \
+  --arg pypiUrl "${PYPI_REPOSITORY_URL:-}" \
+  --arg artifactoryHost "${ARTIFACTORY_TRUSTED_HOST:-}" \
   --arg imageRegistry "${IMAGE_REGISTRY:-docker.io}" '
   .spec.template.spec.containers[0].env //= [] |
   .spec.template.spec.containers[0].image = $imageRegistry+"/python:3.12-slim" |
@@ -303,7 +303,7 @@ yq -o=json "$TMP_JOB_YAML" | jq \
           ]
         else [] end
       )
-' | yq -P > "$PATCHED_TMP_JOB_YAML"
+' | yq r - > "$PATCHED_TMP_JOB_YAML"
 
 mv "$PATCHED_TMP_JOB_YAML" "$TMP_JOB_YAML"
 

--- a/kind/deploy-netbox.sh
+++ b/kind/deploy-netbox.sh
@@ -231,7 +231,7 @@ if [[ "$FORCE_NETBOX_NGINX_IPV4" == "true" ]]; then
     }
   ]'
 
- # Cleanup old ReplicaSets after NetBox deployment patch to prevent volume Multi-Attach errors
+  # Cleanup old ReplicaSets after NetBox deployment patch to prevent volume Multi-Attach errors
   DEPLOYMENT_NAME="netbox"
   # Get all ReplicaSets in JSON
   RS_JSON=$(eval "$KUBECTL get rs -n $NAMESPACE -l app.kubernetes.io/component=netbox -o json" | sed '/^{/,$!d')
@@ -257,6 +257,10 @@ if [[ "$FORCE_NETBOX_NGINX_IPV4" == "true" ]]; then
       ))
     | .[].metadata.name
   ' | xargs -r -I{} ${KUBECTL} delete rs {} -n "$NAMESPACE"
+
+  echo "Forcing restart of netbox pod to reattach volume cleanly..."
+  ${KUBECTL} get pods -n "$NAMESPACE" -l app.kubernetes.io/component=netbox \
+    -o name | xargs -r ${KUBECTL} delete -n "$NAMESPACE" --grace-period=0 --force
 fi
 
 ${KUBECTL} rollout status --namespace="${NAMESPACE}" deployment netbox

--- a/kind/deploy-netbox.sh
+++ b/kind/deploy-netbox.sh
@@ -286,7 +286,7 @@ NETBOX_API_URL="http://netbox.${NAMESPACE}.svc.cluster.local"
 PATCHED_TMP_JOB_YAML="$(mktemp)"
 
 # Convert YAML to JSON and inject variables if containers exist
-yq r -j "$TMP_JOB_YAML" | jq \
+yq eval -o=json "$TMP_JOB_YAML" | jq \
   --arg netboxApi "$NETBOX_API_URL" \
   --arg pypiUrl "${PYPI_REPOSITORY_URL:-}" \
   --arg artifactoryHost "${ARTIFACTORY_TRUSTED_HOST:-}" \
@@ -303,7 +303,7 @@ yq r -j "$TMP_JOB_YAML" | jq \
           ]
         else [] end
       )
-' | yq r - > "$PATCHED_TMP_JOB_YAML"
+' | yq eval -P - > "$PATCHED_TMP_JOB_YAML"
 
 mv "$PATCHED_TMP_JOB_YAML" "$TMP_JOB_YAML"
 

--- a/kind/go.mod
+++ b/kind/go.mod
@@ -1,1 +1,0 @@
-module kind

--- a/kind/go.mod
+++ b/kind/go.mod
@@ -1,0 +1,1 @@
+module kind

--- a/kind/netbox-db/netbox-db.yaml
+++ b/kind/netbox-db/netbox-db.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   teamId: "netbox"
   volume:
-    size: 100Mi
+    size: 5Gi
   numberOfInstances: 1
   enableMasterLoadBalancer: true
   users:


### PR DESCRIPTION
### Context

When deploying NetBox with `FORCE_NETBOX_NGINX_IPV4=true`, the script patches the NetBox `Deployment` to mount a custom `nginx-unit.json` config. This change triggers a new ReplicaSet and Pod, but the old ReplicaSet and its pod may linger during rollout.

Since the NetBox pod uses a PVC with `ReadWriteOnce` access mode, Kubernetes prevents simultaneous attachment to the new pod. This causes a volume `Multi-Attach` error and stalls the deployment.

### Solution

- Identify the latest ReplicaSet owned by the `netbox` deployment
- Delete the older ReplicaSets to free any attached volumes