### PR TITLE
enable formatting for the description field

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ type OperatorConfig struct {
 	HttpsEnable                    bool   `mapstructure:"HTTPS_ENABLE"`
 	DebugEnable                    bool   `mapstructure:"DEBUG_ENABLE"`
 	NetboxRestorationHashFieldName string `mapstructure:"NETBOX_RESTORATION_HASH_FIELD_NAME"`
+	DescriptionFormat              string `mapstructure:"DESCRIPTION_FORMAT"`
 }
 
 func (c *OperatorConfig) setDefaults() {
@@ -47,6 +48,7 @@ func (c *OperatorConfig) setDefaults() {
 	c.viper.SetDefault("HTTPS_ENABLE", true)
 	c.viper.SetDefault("DEBUG_ENABLE", false)
 	c.viper.SetDefault("NETBOX_RESTORATION_HASH_FIELD_NAME", "netboxOperatorRestorationHash")
+	c.viper.SetDefault("DESCRIPTION_FORMAT", "${name} ${description} ${warning}")
 }
 
 func (c *OperatorConfig) LoadCaCert() (cert []byte, err error) {

--- a/pkg/netbox/api/helper.go
+++ b/pkg/netbox/api/helper.go
@@ -114,3 +114,24 @@ func SetIpAddressMask(ip string, ipFamily int64) (string, error) {
 		return "", errors.New("unknown IP family")
 	}
 }
+
+// FormatDescription formats a description string using the configured format template.
+// It supports substitution of the following placeholders:
+// * ${name}: the name of the object (e.g., "test-namespace/test-resource-name")
+// * ${description}: the description provided by the user in spec.description
+// * ${warning}: the static warning comment provided by the operator
+//
+// The default format is "${name} ${description} ${warning}".
+func FormatDescription(template, name, description string) string {
+
+	// Replace placeholders
+	result := strings.ReplaceAll(template, "${name}", name)
+	result = strings.ReplaceAll(result, "${description}", description)
+	result = strings.ReplaceAll(result, "${warning}", warningComment)
+
+	// Truncate to the max length that Netbox allows
+	if utf8.RuneCountInString(result) > maxAllowedDescriptionLength {
+		result = result[:maxAllowedDescriptionLength]
+	}
+	return result
+}

--- a/pkg/netbox/api/prefix.go
+++ b/pkg/netbox/api/prefix.go
@@ -41,14 +41,13 @@ func (r *NetboxClient) ReserveOrUpdatePrefix(prefix *models.Prefix) (*netboxMode
 		Prefix:       &prefix.Prefix,
 		Comments:     prefix.Metadata.Comments + warningComment,
 		CustomFields: prefix.Metadata.Custom,
-		Description:  prefix.Metadata.Description + warningComment,
+		Description:  prefix.Metadata.Description,
 		Status:       "active",
 	}
 
 	if prefix.Metadata != nil {
 		desiredPrefix.CustomFields = prefix.Metadata.Custom
 		desiredPrefix.Comments = prefix.Metadata.Comments + warningComment
-		desiredPrefix.Description = TruncateDescription(prefix.Metadata.Description)
 	}
 
 	if prefix.Metadata != nil && prefix.Metadata.Tenant != "" {


### PR DESCRIPTION
This isn't ready but I wanted to open an example of what I am thinking about to get feedback. Is this in the right direction? I've kept the scope to just the `description` field and not `comments` and to one resource just to keep the PR small.