### PR TITLE
Add codespell CI job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,4 +66,3 @@ jobs:
         uses: codespell-project/actions-codespell@v2
         with:
           skip: '*.svg'
-          path: /

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,3 +58,11 @@ jobs:
           echo "Please run make generate manifests and commit the changes."
           exit 1
           fi
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          skip: '*.svg'
+          path: /

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -61,6 +61,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Run codespell
         uses: codespell-project/actions-codespell@v2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 permissions: read-all
 jobs:
-  run:
+  go-and-crds:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -2,7 +2,7 @@
 
 This folder shows some examples how the NetBox Operator can be used.
 
-Each example folder contains a README.md which explains how you can set up your local enviroment to step through the examples.
+Each example folder contains a README.md which explains how you can set up your local environment to step through the examples.
 
 Prerequisites:
 - go version v1.24.0+

--- a/docs/examples/example2-load-balancer-ip/README.md
+++ b/docs/examples/example2-load-balancer-ip/README.md
@@ -50,7 +50,7 @@ kubectl get pxc,ipaddresspool -A
 ```bash
 cat sample-deployment.yaml
 ```
-5. Apply the manifests to createa deployment with a service that gets a ip assigned from the metalLB pool created in the prevoius step
+5. Apply the manifests to create deployment with a service that gets a ip assigned from the metalLB pool created in the previous step
 ```bash
 kubectl apply -f sample-deployment.yaml
 ```

--- a/docs/examples/example5-multicluster/zurich-pools.yaml
+++ b/docs/examples/example5-multicluster/zurich-pools.yaml
@@ -7,7 +7,7 @@ spec:
   prefixLength: "/30"
   parentPrefixSelector:
     environment: prod
-    familiy: IPv4
+    family: IPv4
 ---
 apiVersion: netbox.dev/v1
 kind: PrefixClaim

--- a/internal/controller/expected_netboxmock_calls_test.go
+++ b/internal/controller/expected_netboxmock_calls_test.go
@@ -55,7 +55,7 @@ func mockIpAddressListWithIpAddressFilterEmptyResult(ipamMock *mock_interfaces.M
 				catchUnexpectedParams <- err
 				return &ipam.IpamIPAddressesListOK{Payload: nil}, err
 			}
-			fmt.Printf("NETBOXMOCK\t ipam.IpamIPAddressesList (empty reslut) was called with expected input,\n")
+			fmt.Printf("NETBOXMOCK\t ipam.IpamIPAddressesList (empty result) was called with expected input,\n")
 			return &ipam.IpamIPAddressesListOK{Payload: mockedResponseEmptyIPAddressList()}, nil
 		}).MinTimes(1)
 }
@@ -71,7 +71,7 @@ func mockIpAddressListWithHashFilterEmptyResult(ipamMock *mock_interfaces.MockIp
 				catchUnexpectedParams <- err
 				return &ipam.IpamIPAddressesListOK{Payload: nil}, err
 			}
-			fmt.Printf("NETBOXMOCK\t ipam.IpamIPAddressesList (empty reslut) was called with expected input,\n")
+			fmt.Printf("NETBOXMOCK\t ipam.IpamIPAddressesList (empty result) was called with expected input,\n")
 			return &ipam.IpamIPAddressesListOK{Payload: mockedResponseEmptyIPAddressList()}, nil
 		}).MinTimes(1)
 }
@@ -87,7 +87,7 @@ func mockIpAddressListWithHashFilter(ipamMock *mock_interfaces.MockIpamInterface
 				catchUnexpectedParams <- err
 				return &ipam.IpamIPAddressesListOK{Payload: nil}, err
 			}
-			fmt.Printf("NETBOXMOCK\t ipam.IpamIPAddressesList (empty reslut) was called with expected input,\n")
+			fmt.Printf("NETBOXMOCK\t ipam.IpamIPAddressesList (empty result) was called with expected input,\n")
 			return &ipam.IpamIPAddressesListOK{Payload: mockedResponseIPAddressList()}, nil
 		}).MinTimes(1)
 }
@@ -103,7 +103,7 @@ func mockIpAddressListWithHashFilterMismatch(ipamMock *mock_interfaces.MockIpamI
 				catchUnexpectedParams <- err
 				return &ipam.IpamIPAddressesListOK{Payload: nil}, err
 			}
-			fmt.Printf("NETBOXMOCK\t ipam.IpamIPAddressesList (empty reslut) was called with expected input,\n")
+			fmt.Printf("NETBOXMOCK\t ipam.IpamIPAddressesList (empty result) was called with expected input,\n")
 			return &ipam.IpamIPAddressesListOK{Payload: mockedResponseIPAddressListWithHash(customFieldsWithHashMismatch)}, nil
 		}).MinTimes(1)
 }

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -163,7 +163,7 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					return ctrl.Result{Requeue: true}, nil
 				}
 				if len(parentPrefixCandidates) == 0 {
-					message := "no parent prefix found matching the parenPrefixSelector"
+					message := "no parent prefix found matching the parentPrefixSelector"
 					r.EventStatusRecorder.Recorder().Event(prefixClaim, corev1.EventTypeWarning, netboxv1.ConditionPrefixAssignedFalse.Reason, netboxv1.ConditionPrefixAssignedFalse.Message+": "+message)
 					if err := r.EventStatusRecorder.Report(ctx, prefixClaim, netboxv1.ConditionPrefixAssignedFalse, corev1.EventTypeWarning, errors.New(message)); err != nil {
 						return ctrl.Result{}, err

--- a/internal/controller/prefixclaim_helpers_test.go
+++ b/internal/controller/prefixclaim_helpers_test.go
@@ -26,7 +26,7 @@ func testPrefixClaimHash(t *testing.T, prefixClaim *netboxv1.PrefixClaim, expect
 	generatedHash := generatePrefixRestorationHash(prefixClaim)
 
 	if generatedHash != expectedHash {
-		t.Errorf("hash mistatch: expected %#v, got %#v from %#v", expectedHash, generatedHash, prefixClaim)
+		t.Errorf("hash mismatch: expected %#v, got %#v from %#v", expectedHash, generatedHash, prefixClaim)
 	}
 }
 

--- a/pkg/netbox/api/ip_address_claim_test.go
+++ b/pkg/netbox/api/ip_address_claim_test.go
@@ -359,7 +359,7 @@ func TestIPAddressClaim_GetNoAvailableIPAddressWithTenancyChecks(t *testing.T) {
 	mockTenancy := mock_interfaces.NewMockTenancyInterface(ctrl)
 
 	parentPrefix := "10.112.140.0/24"
-	t.Run("No IP address asigned with an error when getting the tenant list", func(t *testing.T) {
+	t.Run("No IP address assigned with an error when getting the tenant list", func(t *testing.T) {
 
 		tenantName := "Tenant1"
 
@@ -388,7 +388,7 @@ func TestIPAddressClaim_GetNoAvailableIPAddressWithTenancyChecks(t *testing.T) {
 		assert.Equal(t, actual, (*models.IPAddress)(nil))
 	})
 
-	t.Run("No IP address asigned with non-existing tenant", func(t *testing.T) {
+	t.Run("No IP address assigned with non-existing tenant", func(t *testing.T) {
 
 		// non existing tenant
 		nonExistingTenant := "non-existing-tenant"

--- a/pkg/netbox/api/ip_address_test.go
+++ b/pkg/netbox/api/ip_address_test.go
@@ -214,7 +214,7 @@ func TestIPAddress(t *testing.T) {
 
 	t.Run("Reserve Static IP Address.", func(t *testing.T) {
 
-		// ip address mock inout
+		// ip address mock input
 		input := ipam.NewIpamIPAddressesCreateParams().WithDefaults().WithData(writeableAddress())
 		// ip address mock output
 		output := &ipam.IpamIPAddressesCreateCreated{

--- a/pkg/netbox/api/ip_range_claim_test.go
+++ b/pkg/netbox/api/ip_range_claim_test.go
@@ -49,7 +49,7 @@ func TestIPRangeClaim(t *testing.T) {
 	expectedIpDot5 := "10.112.140.5/32"
 	expectedIpDot7 := "10.112.140.7/32"
 
-	// example of available IPv4 ip adress
+	// example of available IPv4 ip address
 	availableIpAdressesIPv4 := func() []*netboxModels.AvailableIP {
 		return []*netboxModels.AvailableIP{
 			{

--- a/pkg/netbox/api/prefix_claim.go
+++ b/pkg/netbox/api/prefix_claim.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	// TODO(henrybear327): centralize errors
-	ErrNoPrefixMatchsSizeCriteria = errors.New("no available prefix matches size criterias")
+	ErrNoPrefixMatchsSizeCriteria = errors.New("no available prefix matches size criteria")
 )
 
 func (r *NetboxClient) RestoreExistingPrefixByHash(hash string) (*models.Prefix, error) {
@@ -313,7 +313,7 @@ func (r *NetboxClient) GetAvailablePrefixesByParentPrefix(parentPrefixId int64) 
 }
 
 func getSmallestMatchingPrefix(prefixList *ipam.IpamPrefixesAvailablePrefixesListOK, prefixClaimLengthString string) (string, bool, error) {
-	// input valiation
+	// input validation
 	if len(prefixClaimLengthString) == 0 {
 		return "", false, errors.New("invalid prefixClaimLengthString: empty string")
 	}

--- a/pkg/netbox/api/prefix_test.go
+++ b/pkg/netbox/api/prefix_test.go
@@ -424,7 +424,7 @@ func TestPrefix_ReserveOrUpdate(t *testing.T) {
 		}
 
 		_, err := netboxClient.ReserveOrUpdatePrefix(&prefixModel)
-		// skip assertion on retured values as the payload of IpamPrefixesCreate() is returened
+		// skip assertion on returned values as the payload of IpamPrefixesCreate() is returned
 		// without manipulation by the code
 		assert.Nil(t, err)
 	})
@@ -477,7 +477,7 @@ func TestPrefix_ReserveOrUpdate(t *testing.T) {
 		}
 
 		_, err := netboxClient.ReserveOrUpdatePrefix(&prefixModel)
-		// skip assertion on retured values as the payload of IpamPrefixesUpdate() is returened
+		// skip assertion on returned values as the payload of IpamPrefixesUpdate() is returned
 		// without manipulation by the code
 		assert.Nil(t, err)
 	})
@@ -519,7 +519,7 @@ func TestPrefix_ReserveOrUpdate(t *testing.T) {
 		}
 
 		_, err := netboxClient.ReserveOrUpdatePrefix(&prefixModel)
-		// skip assertion on retured values as the payload of IpamPrefixesCreate() is returened
+		// skip assertion on returned values as the payload of IpamPrefixesCreate() is returned
 		// without manipulation by the code
 		AssertError(t, err, "restoration hash mismatch, assigned prefix 10.112.140.0/24")
 	})

--- a/pkg/netbox/api/site_test.go
+++ b/pkg/netbox/api/site_test.go
@@ -93,7 +93,7 @@ func TestSite_GetError(t *testing.T) {
 
 	siteListRequestInput := dcim.NewDcimSitesListParams().WithName(&site)
 
-	expectedErr := "error geting sites list"
+	expectedErr := "error getting sites list"
 
 	mockDcim.EXPECT().DcimSitesList(siteListRequestInput, nil).Return(nil, errors.New(expectedErr))
 	netboxClient := &NetboxClient{Dcim: mockDcim}

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
@@ -4,7 +4,7 @@ kind: Test
 metadata:
   name: prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield
   annotations:
-    description: Tests if creation fails for parentPrefixSelector with non exising custom field
+    description: Tests if creation fails for parentPrefixSelector with non existing custom field
 spec:
   steps:
     - name: Apply CR


### PR DESCRIPTION
Adds a codespell CI job and fixes current spelling issues using `codespell --skip="*.svg" --write-changes`