### PR TITLE
Add ownerReference to child resource on update

### DIFF
--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -186,16 +186,16 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 
 		updatedIpAddressSpec := generateIpAddressSpec(o, ipAddress.Spec.IpAddress, logger)
-		err = controllerutil.SetControllerReference(o, ipAddress, r.Scheme)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
 		_, err = ctrl.CreateOrUpdate(ctx, r.Client, ipAddress, func() error {
 			// only add the mutable fields here
 			ipAddress.Spec.CustomFields = updatedIpAddressSpec.CustomFields
 			ipAddress.Spec.Comments = updatedIpAddressSpec.Comments
 			ipAddress.Spec.Description = updatedIpAddressSpec.Description
 			ipAddress.Spec.PreserveInNetbox = updatedIpAddressSpec.PreserveInNetbox
+			err = controllerutil.SetControllerReference(o, ipAddress, r.Scheme)
+			if err != nil {
+				return err
+			}
 			return nil
 		})
 		if err != nil {

--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -186,6 +186,10 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 
 		updatedIpAddressSpec := generateIpAddressSpec(o, ipAddress.Spec.IpAddress, logger)
+		err = controllerutil.SetControllerReference(o, ipAddress, r.Scheme)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 		_, err = ctrl.CreateOrUpdate(ctx, r.Client, ipAddress, func() error {
 			// only add the mutable fields here
 			ipAddress.Spec.CustomFields = updatedIpAddressSpec.CustomFields

--- a/internal/controller/iprangeclaim_controller.go
+++ b/internal/controller/iprangeclaim_controller.go
@@ -147,6 +147,11 @@ func (r *IpRangeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// update spec of IpRange object
 		logger.V(4).Info("update iprange resource")
 		ipRange.Spec = generateIpRangeSpec(o, ipRange.Spec.StartAddress, ipRange.Spec.EndAddress, logger)
+		err = controllerutil.SetControllerReference(o, ipRange, r.Scheme)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
 		err = r.Client.Update(ctx, ipRange)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -311,6 +311,11 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		updatedPrefixSpec := generatePrefixSpec(prefixClaim, prefix.Spec.Prefix, logger)
+		err = controllerutil.SetControllerReference(prefixClaim, prefix, r.Scheme)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
 		if _, err = ctrl.CreateOrUpdate(ctx, r.Client, prefix, func() error {
 			// only add the mutable fields here
 			prefix.Spec.Site = updatedPrefixSpec.Site

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -311,11 +311,6 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		updatedPrefixSpec := generatePrefixSpec(prefixClaim, prefix.Spec.Prefix, logger)
-		err = controllerutil.SetControllerReference(prefixClaim, prefix, r.Scheme)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
 		if _, err = ctrl.CreateOrUpdate(ctx, r.Client, prefix, func() error {
 			// only add the mutable fields here
 			prefix.Spec.Site = updatedPrefixSpec.Site
@@ -323,6 +318,10 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			prefix.Spec.Description = updatedPrefixSpec.Description
 			prefix.Spec.Comments = updatedPrefixSpec.Comments
 			prefix.Spec.PreserveInNetbox = updatedPrefixSpec.PreserveInNetbox
+			err = controllerutil.SetControllerReference(prefixClaim, prefix, r.Scheme)
+			if err != nil {
+				return err
+			}
 			return nil
 		}); err != nil {
 			return ctrl.Result{}, err

--- a/kind/load-local-data-job/main.py
+++ b/kind/load-local-data-job/main.py
@@ -350,7 +350,7 @@ prefixes = [
     ),
     Prefix(
         prefix="3.0.5.0/24",
-        description="",
+        description="chainsaw test prefixclaim-ipv4-update-ownerreference",
         site=None,
         tenant={
             "name": "MY_TENANT",

--- a/kind/load-local-data-job/main.py
+++ b/kind/load-local-data-job/main.py
@@ -525,7 +525,7 @@ prefixes = [
     ),
     Prefix(
         prefix="3.1.3.0/24",
-        description="",
+        description="chainsaw test ipaddressclaim-ipv4-update-ownerreference",
         site=None,
         tenant={
             "name": "MY_TENANT",

--- a/kind/load-local-data-job/main.py
+++ b/kind/load-local-data-job/main.py
@@ -766,7 +766,7 @@ prefixes = [
     ),
     Prefix(
         prefix="3.2.4.0/24",
-        description="",
+        description="chainsaw test iprangeclaim-ipv4-update-ownerreference",
         site=None,
         tenant={
             "name": "MY_TENANT",

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -54,4 +53,4 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-invalid-parentprefixselector -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-invalid-parentprefixselector -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/netbox_v1_prefixclaim.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-invalid-parentprefixselector/netbox_v1_prefixclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -84,4 +83,4 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-apply-update -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-apply-update -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/netbox_v1_prefixclaim-update.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/netbox_v1_prefixclaim-update.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/netbox_v1_prefixclaim.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-apply-update/netbox_v1_prefixclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -133,46 +132,46 @@ spec:
     - name: Set preserveInNetbox to false
       description: Set preserveInNetbox to false to clean up the NetBox test instance
       try:
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: PrefixClaim
-            metadata:
-              name: prefixclaim-ipv4-parentprefix-restore-1
-            spec:
-              preserveInNetbox: false
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: PrefixClaim
-            metadata:
-              name: prefixclaim-ipv4-parentprefix-restore-2
-            spec:
-              preserveInNetbox: false
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: Prefix
-            metadata:
-              name: prefixclaim-ipv4-parentprefix-restore-1
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 2
-                status: 'True'
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: Prefix
-            metadata:
-              name: prefixclaim-ipv4-parentprefix-restore-2
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 2
-                status: 'True'
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefix-restore-1
+              spec:
+                preserveInNetbox: false
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefix-restore-2
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefix-restore-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 2
+                    status: 'True'
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefix-restore-2
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 2
+                    status: 'True'
     - name: Cleanup events
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-restore-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-restore-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-restore-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefix-restore-2 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/netbox_v1_prefixclaim_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/netbox_v1_prefixclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/netbox_v1_prefixclaim_2.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefix-restore/netbox_v1_prefixclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -63,4 +62,4 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/netbox_v1_prefixclaim.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-nonexisingcustomfield/netbox_v1_prefixclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -146,28 +145,28 @@ spec:
     - name: Set preserveInNetbox to false
       description: Set preserveInNetbox to false to clean up the NetBox test instance
       try:
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: PrefixClaim
-            metadata:
-              name: prefixclaim-ipv4-parentprefixselector-restore-1
-            spec:
-              preserveInNetbox: false
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: Prefix
-            metadata:
-              name: prefixclaim-ipv4-parentprefixselector-restore-1
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 2
-                status: 'True'
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-restore-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-restore-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 2
+                    status: 'True'
     - name: Cleanup events
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-restore-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-restore-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-restore-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-restore-2 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/netbox_v1_prefixclaim_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/netbox_v1_prefixclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/netbox_v1_prefixclaim_2.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector-restore/netbox_v1_prefixclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -53,27 +52,27 @@ spec:
     - name: Set preserveInNetbox to false
       description: Set preserveInNetbox to false to clean up the NetBox test instance
       try:
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: PrefixClaim
-            metadata:
-              name: prefixclaim-ipv4-parentprefixselector-apply
-            spec:
-              preserveInNetbox: false
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: Prefix
-            metadata:
-              name: prefixclaim-ipv4-parentprefixselector-apply
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 2
-                status: 'True'
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-apply
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-apply
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 2
+                    status: 'True'
     - name: Cleanup events
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-apply -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-apply -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector/netbox_v1_prefixclaim.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-parentprefixselector/netbox_v1_prefixclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -103,6 +102,6 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-3 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/netbox_v1_prefixclaim_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/netbox_v1_prefixclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/netbox_v1_prefixclaim_2.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/netbox_v1_prefixclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/netbox_v1_prefixclaim_3.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-prefixexhausted/netbox_v1_prefixclaim_3.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: prefixclaim-ipv4-update-ownerreference
+  annotations:
+    description: Tests if controller updates ownerReference if non-Claim resource existed before (e.g. from a velero backup)
+spec:
+  steps:
+    - name: Apply CR 1
+      try:
+        - apply:
+            file: netbox_v1_prefix_1.yaml
+    - name: Check non-claim CR 1 spec and status
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-update-ownerreference-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: "True"
+    - name: Apply CR 1
+      try:
+        - apply:
+            file: netbox_v1_prefixclaim_1.yaml
+    - name: Check claim CR 1 spec and status
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-update-ownerreference-1
+              spec:
+                comments: your comments
+                description: some description
+                parentPrefix: 3.0.5.0/24
+                prefixLength: /28
+                preserveInNetbox: false
+                tenant: MY_TENANT
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: "True"
+                parentPrefix: 3.0.5.0/24
+                prefix: 3.0.5.0/28
+                prefixName: prefixclaim-ipv4-update-ownerreference-1
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                finalizers:
+                  - prefix.netbox.dev/finalizer
+                name: prefixclaim-ipv4-update-ownerreference-1
+                ownerReferences:
+                  - apiVersion: netbox.dev/v1
+                    blockOwnerDeletion: true
+                    controller: true
+                    kind: PrefixClaim
+                    name: prefixclaim-ipv4-update-ownerreference-1
+              spec:
+                comments: your comments
+                customFields:
+                  netboxOperatorRestorationHash: 8ed6d9825bc218cf0b6f7ab39272637d95d318a4
+                description: some description
+                prefix: 3.0.5.0/28
+                tenant: MY_TENANT
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: "True"
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            content: |
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-update-ownerreference-1 -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefix_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefix_1.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: netbox.dev/v1
+kind: Prefix
+metadata:
+  annotations:
+    prefix.netbox.dev/managed-custom-fields: '{"netboxOperatorRestorationHash":"220971234e851b248c2be6ac047f1d62a1ee9a38"}'
+  name: prefixclaim-ipv4-update-ownerreference-1
+spec:
+  comments: your comments
+  customFields:
+    netboxOperatorRestorationHash: 220971234e851b248c2be6ac047f1d62a1ee9a38
+  description: some description
+  prefix: 3.0.5.0/28
+  tenant: MY_TENANT

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefix_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefix_1.yaml
@@ -2,8 +2,6 @@
 apiVersion: netbox.dev/v1
 kind: Prefix
 metadata:
-  annotations:
-    prefix.netbox.dev/managed-custom-fields: '{"netboxOperatorRestorationHash":"220971234e851b248c2be6ac047f1d62a1ee9a38"}'
   name: prefixclaim-ipv4-update-ownerreference-1
 spec:
   comments: your comments

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefix_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefix_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: Prefix
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefix_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefix_1.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   comments: your comments
   customFields:
-    netboxOperatorRestorationHash: 220971234e851b248c2be6ac047f1d62a1ee9a38
+    netboxOperatorRestorationHash: 8ed6d9825bc218cf0b6f7ab39272637d95d318a4
   description: some description
   prefix: 3.0.5.0/28
   tenant: MY_TENANT

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefixclaim_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefixclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: PrefixClaim
 metadata:

--- a/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefixclaim_1.yaml
+++ b/tests/e2e/Prefix/IPv4/prefixclaim-ipv4-update-ownerreference/netbox_v1_prefixclaim_1.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: netbox.dev/v1
+kind: PrefixClaim
+metadata:
+  name: prefixclaim-ipv4-update-ownerreference-1
+spec:
+  comments: your comments
+  description: some description
+  parentPrefix: 3.0.5.0/24
+  preserveInNetbox: false
+  tenant: MY_TENANT
+  prefixLength: "/28"

--- a/tests/e2e/Prefix/IPv6/prefixclaim-ipv6-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/Prefix/IPv6/prefixclaim-ipv6-apply-update/chainsaw-test.yaml
@@ -89,27 +89,27 @@ spec:
     - name: Set preserveInNetbox to false
       description: Set preserveInNetbox to false to clean up the NetBox test instance
       try:
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: PrefixClaim
-            metadata:
-              name: prefixclaim-ipv6-apply-update
-            spec:
-              preserveInNetbox: false
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: Prefix
-            metadata:
-              name: prefixclaim-ipv6-apply-update
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 3
-                status: 'True'
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv6-apply-update
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv6-apply-update
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 3
+                    status: 'True'
     - name: Cleanup events
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv6-apply-update -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv6-apply-update -n $NAMESPACE

--- a/tests/e2e/Prefix/IPv6/prefixclaim-ipv6-apply-update/netbox_v1_prefixclaim.yaml
+++ b/tests/e2e/Prefix/IPv6/prefixclaim-ipv6-apply-update/netbox_v1_prefixclaim.yaml
@@ -15,6 +15,5 @@ spec:
     # if the entry for tenant or site is missing, it will *not* inherit from the tenant and site from the Spec
     tenant: "MY_TENANT" # Use the `name` value instead of the `slug` value
     family: "IPv6" # Can only be either IPv4 or IPv6"
-    
     environment: "production"
     poolName: "pool 4"

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -112,4 +111,4 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-apply-update -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-apply-update -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/netbox_v1_ipaddressclaim-update.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/netbox_v1_ipaddressclaim-update.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/netbox_v1_ipaddressclaim.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-apply-update/netbox_v1_ipaddressclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -118,7 +117,7 @@ spec:
                 preserveInNetbox: false
                 tenant: MY_TENANT
               status:
-                (conditions[?type == 'IPAssigned']):  # TODO(jstudler): Change this to Ready, will need change in SetConditionAndCreateEvent to also update Ready condition
+                (conditions[?type == 'IPAssigned']): # TODO(jstudler): Change this to Ready, will need change in SetConditionAndCreateEvent to also update Ready condition
                   - status: 'False'
         - assert:
             resource:
@@ -138,6 +137,6 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-3 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/netbox_v1_ipaddressclaim_1.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/netbox_v1_ipaddressclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/netbox_v1_ipaddressclaim_2.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/netbox_v1_ipaddressclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/netbox_v1_ipaddressclaim_3.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-prefixexhausted/netbox_v1_ipaddressclaim_3.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -46,7 +45,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: c7113eab8a61aad6a7618acb510622555d75d0c3  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: c7113eab8a61aad6a7618acb510622555d75d0c3 # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 ipAddress: 3.1.2.1/32
                 preserveInNetbox: true
@@ -147,7 +146,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: c7113eab8a61aad6a7618acb510622555d75d0c3  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: c7113eab8a61aad6a7618acb510622555d75d0c3 # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 ipAddress: 3.1.2.1/32
                 preserveInNetbox: true
@@ -158,28 +157,28 @@ spec:
     - name: Set preserveInNetbox to false
       description: Set preserveInNetbox to false to clean up the NetBox test instance
       try:
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: IpAddressClaim
-            metadata:
-              name: ipaddressclaim-ipv4-restore-1
-            spec:
-              preserveInNetbox: false
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: IpAddress
-            metadata:
-              name: ipaddressclaim-ipv4-restore-1
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 2
-                status: 'True'
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpAddressClaim
+              metadata:
+                name: ipaddressclaim-ipv4-restore-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpAddress
+              metadata:
+                name: ipaddressclaim-ipv4-restore-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 2
+                    status: 'True'
     - name: Cleanup events
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-restore-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-restore-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-restore-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-restore-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/netbox_v1_ipaddressclaim_1.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/netbox_v1_ipaddressclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/netbox_v1_ipaddressclaim_2.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-restore/netbox_v1_ipaddressclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -62,7 +61,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: e93f42d53e5114c6ef44ba878893856411596bbf  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: e93f42d53e5114c6ef44ba878893856411596bbf # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 ipAddress: 3.1.3.1/32
                 tenant: MY_TENANT
@@ -74,4 +73,4 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-update-ownerreference-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-update-ownerreference-1 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -75,4 +75,3 @@ spec:
         - script:
             content: |
                 kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-update-ownerreference-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-update-ownerreference-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ipaddressclaim-ipv4-update-ownerreference
+  annotations:
+    description: Tests if controller updates ownerReference if non-Claim resource existed before (e.g. from a velero backup)
+spec:
+  steps:
+    - name: Apply CR 1
+      try:
+        - apply:
+            file: netbox_v1_ipaddress_1.yaml
+    - name: Check non-claim CR 1 spec and status
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpAddress
+              metadata:
+                name: ipaddressclaim-ipv4-update-ownerreference-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Apply CR 1
+      try:
+        - apply:
+            file: netbox_v1_ipaddressclaim_1.yaml
+    - name: Check claim CR 1 spec and status
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpAddressClaim
+              metadata:
+                name: ipaddressclaim-ipv4-update-ownerreference-1
+              spec:
+                comments: your comments
+                description: some description
+                parentPrefix: 3.1.3.0/24
+                tenant: MY_TENANT
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+                ipAddress: 3.1.3.1/32
+                ipAddressDotDecimal: 3.1.3.1
+                ipAddressName: ipaddressclaim-ipv4-update-ownerreference-1
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpAddress
+              metadata:
+                name: ipaddressclaim-ipv4-update-ownerreference-1
+                finalizers:
+                  - ipaddress.netbox.dev/finalizer
+                ownerReferences:
+                  - apiVersion: netbox.dev/v1
+                    blockOwnerDeletion: true
+                    controller: true
+                    kind: IpAddressClaim
+                    name: ipaddressclaim-ipv4-update-ownerreference-1
+              spec:
+                comments: your comments
+                customFields:
+                  netboxOperatorRestorationHash: e93f42d53e5114c6ef44ba878893856411596bbf  # note that this will require the tests to run in the e2e namespace!
+                description: some description
+                ipAddress: 3.1.3.1/32
+                tenant: MY_TENANT
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            content: |
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-update-ownerreference-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv4-update-ownerreference-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/netbox_v1_ipaddress_1.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/netbox_v1_ipaddress_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddress
 metadata:

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/netbox_v1_ipaddress_1.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/netbox_v1_ipaddress_1.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: netbox.dev/v1
+kind: IpAddress
+metadata:
+  name: ipaddressclaim-ipv4-update-ownerreference-1
+spec:
+  comments: your comments
+  customFields:
+    netboxOperatorRestorationHash: e93f42d53e5114c6ef44ba878893856411596bbf
+  description: some description
+  ipAddress: 3.1.3.1/32
+  tenant: MY_TENANT

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/netbox_v1_ipaddressclaim_1.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/netbox_v1_ipaddressclaim_1.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: netbox.dev/v1
+kind: IpAddressClaim
+metadata:
+  name: ipaddressclaim-ipv4-update-ownerreference-1
+spec:
+  comments: your comments
+  description: some description
+  parentPrefix: 3.1.3.0/24
+  preserveInNetbox: false
+  tenant: MY_TENANT

--- a/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/netbox_v1_ipaddressclaim_1.yaml
+++ b/tests/e2e/ipaddress/ipv4/ipaddressclaim-ipv4-update-ownerreference/netbox_v1_ipaddressclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -112,4 +111,4 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-apply-update -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-apply-update -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/netbox_v1_ipaddressclaim-update.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/netbox_v1_ipaddressclaim-update.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/netbox_v1_ipaddressclaim.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-apply-update/netbox_v1_ipaddressclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -118,7 +117,7 @@ spec:
                 preserveInNetbox: false
                 tenant: MY_TENANT
               status:
-                (conditions[?type == 'IPAssigned']):  # TODO(jstudler): Change this to Ready, will need change in SetConditionAndCreateEvent to also update Ready condition
+                (conditions[?type == 'IPAssigned']): # TODO(jstudler): Change this to Ready, will need change in SetConditionAndCreateEvent to also update Ready condition
                   - status: 'False'
         - assert:
             resource:
@@ -138,6 +137,6 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-2 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-3 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/netbox_v1_ipaddressclaim_1.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/netbox_v1_ipaddressclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/netbox_v1_ipaddressclaim_2.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/netbox_v1_ipaddressclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/netbox_v1_ipaddressclaim_3.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-prefixexhausted/netbox_v1_ipaddressclaim_3.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/chainsaw-test.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -46,7 +45,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: bf12294d295d4dadec934bc511dfaa78a87e171b  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: bf12294d295d4dadec934bc511dfaa78a87e171b # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 ipAddress: 3:1:2::1/128
                 preserveInNetbox: true
@@ -147,7 +146,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: bf12294d295d4dadec934bc511dfaa78a87e171b  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: bf12294d295d4dadec934bc511dfaa78a87e171b # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 ipAddress: 3:1:2::1/128
                 preserveInNetbox: true
@@ -158,28 +157,28 @@ spec:
     - name: Set preserveInNetbox to false
       description: Set preserveInNetbox to false to clean up the NetBox test instance
       try:
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: IpAddressClaim
-            metadata:
-              name: ipaddressclaim-ipv6-restore-1
-            spec:
-              preserveInNetbox: false
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: IpAddress
-            metadata:
-              name: ipaddressclaim-ipv6-restore-1
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 2
-                status: 'True'
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpAddressClaim
+              metadata:
+                name: ipaddressclaim-ipv6-restore-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpAddress
+              metadata:
+                name: ipaddressclaim-ipv6-restore-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 2
+                    status: 'True'
     - name: Cleanup events
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-restore-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-restore-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-restore-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=ipaddressclaim-ipv6-restore-2 -n $NAMESPACE

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/netbox_v1_ipaddressclaim_1.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/netbox_v1_ipaddressclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/netbox_v1_ipaddressclaim_2.yaml
+++ b/tests/e2e/ipaddress/ipv6/ipaddressclaim-ipv6-restore/netbox_v1_ipaddressclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpAddressClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-apply-update/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -122,8 +121,8 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox)  # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-apply-update -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox)  # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-apply-update -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-apply-update/netbox_v1_iprangeclaim-update.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-apply-update/netbox_v1_iprangeclaim-update.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-apply-update/netbox_v1_iprangeclaim.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-apply-update/netbox_v1_iprangeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-cidr/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-cidr/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -19,8 +18,8 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-cidr -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-cidr -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-cidr/netbox_v1_iprangeclaim.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-cidr/netbox_v1_iprangeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldnotexisting/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldnotexisting/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -65,8 +64,8 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-customfieldnotexisting -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-customfieldnotexisting -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldnotexisting/netbox_v1_iprangeclaim.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldnotexisting/netbox_v1_iprangeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldwrongdatatype/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldwrongdatatype/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -65,8 +64,8 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-customfieldwrongdatatype -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-customfieldwrongdatatype -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldwrongdatatype/netbox_v1_iprangeclaim.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-customfieldwrongdatatype/netbox_v1_iprangeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -39,8 +38,8 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-parentprefix -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-parentprefix -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/netbox_v1_iprangeclaim.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-parentprefix/netbox_v1_iprangeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-size/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-size/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -19,8 +18,8 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-size -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-size -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-size/netbox_v1_iprangeclaim.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-size/netbox_v1_iprangeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -45,8 +44,8 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-tenant -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-invalid-tenant -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/netbox_v1_iprangeclaim.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-invalid-tenant/netbox_v1_iprangeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -127,7 +126,7 @@ spec:
                 size: 30
                 tenant: MY_TENANT
               status:
-                (conditions[?type == 'IPRangeAssigned']):  # TODO(jstudler): Change this to Ready, will need change in SetConditionAndCreateEvent to also update Ready condition
+                (conditions[?type == 'IPRangeAssigned']): # TODO(jstudler): Change this to Ready, will need change in SetConditionAndCreateEvent to also update Ready condition
                   - status: 'False'
         - assert:
             resource:
@@ -147,10 +146,10 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-3 -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/netbox_v1_iprangeclaim_1.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/netbox_v1_iprangeclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/netbox_v1_iprangeclaim_2.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/netbox_v1_iprangeclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/netbox_v1_iprangeclaim_3.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-prefixexhausted/netbox_v1_iprangeclaim_3.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-restore/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-restore/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -51,7 +50,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: 86776d57746f3262ef6f450b58c375e835bd914c  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: 86776d57746f3262ef6f450b58c375e835bd914c # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 startAddress: 3.2.2.1/32
                 endAddress: 3.2.2.30/32
@@ -163,7 +162,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: 86776d57746f3262ef6f450b58c375e835bd914c  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: 86776d57746f3262ef6f450b58c375e835bd914c # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 startAddress: 3.2.2.1/32
                 endAddress: 3.2.2.30/32
@@ -175,32 +174,32 @@ spec:
     - name: Set preserveInNetbox to false
       description: Set preserveInNetbox to false to clean up the NetBox test instance
       try:
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: IpRangeClaim
-            metadata:
-              name: iprangeclaim-ipv4-restore-1
-            spec:
-              preserveInNetbox: false
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: IpRange
-            metadata:
-              name: iprangeclaim-ipv4-restore-1
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 2
-                status: 'True'
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpRangeClaim
+              metadata:
+                name: iprangeclaim-ipv4-restore-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpRange
+              metadata:
+                name: iprangeclaim-ipv4-restore-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 2
+                    status: 'True'
     - name: Cleanup events and leases
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-restore-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-restore-2 -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-restore-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-restore-2 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-restore/netbox_v1_iprangeclaim_1.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-restore/netbox_v1_iprangeclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-restore/netbox_v1_iprangeclaim_2.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-restore/netbox_v1_iprangeclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -80,4 +79,4 @@ spec:
       cleanup:
         - script:
             content: |
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-update-ownerreference-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-update-ownerreference-1 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -44,7 +44,7 @@ spec:
                   - status: 'True'
                 endAddress: 3.2.4.30/32
                 endAddressDotDecimal: 3.2.4.30
-                ipAddressName: iprangeclaim-ipv4-update-ownerreference-1
+                ipRangeName: iprangeclaim-ipv4-update-ownerreference-1
                 ipRange: 3.2.4.1/32-3.2.4.30/32
                 ipRangeDotDecimal: 3.2.4.1-3.2.4.30
                 startAddress: 3.2.4.1/32

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: iprangeclaim-ipv4-update-ownerreference
+  annotations:
+    description: Tests if controller updates ownerReference if non-Claim resource existed before (e.g. from a velero backup)
+spec:
+  steps:
+    - name: Apply CR 1
+      try:
+        - apply:
+            file: netbox_v1_iprange_1.yaml
+    - name: Check non-claim CR 1 spec and status
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpRange
+              metadata:
+                name: iprangeclaim-ipv4-update-ownerreference-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Apply CR 1
+      try:
+        - apply:
+            file: netbox_v1_iprangeclaim_1.yaml
+    - name: Check claim CR 1 spec and status
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpRangeClaim
+              metadata:
+                name: iprangeclaim-ipv4-update-ownerreference-1
+              spec:
+                comments: your comments
+                description: some description
+                parentPrefix: 3.2.4.0/24
+                size: 30
+                tenant: MY_TENANT
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+                endAddress: 3.2.4.30/32
+                endAddressDotDecimal: 3.2.4.30
+                ipAddressName: iprangeclaim-ipv4-update-ownerreference-1
+                ipRange: 3.2.4.1/32-3.2.4.30/32
+                ipRangeDotDecimal: 3.2.4.1-3.2.4.30
+                startAddress: 3.2.4.1/32
+                startAddressDotDecimal: 3.2.4.1
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpRange
+              metadata:
+                name: iprangeclaim-ipv4-update-ownerreference-1
+                finalizers:
+                  - iprange.netbox.dev/finalizer
+                ownerReferences:
+                  - apiVersion: netbox.dev/v1
+                    blockOwnerDeletion: true
+                    controller: true
+                    kind: IpRangeClaim
+                    name: iprangeclaim-ipv4-update-ownerreference-1
+              spec:
+                comments: your comments
+                customFields:
+                  netboxOperatorRestorationHash: 03cae1a8b295c77a1780a585b44562ed9a780807
+                description: some description
+                endAddress: 3.2.4.30/32
+                startAddress: 3.2.4.1/32
+                tenant: MY_TENANT
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            content: |
+                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-update-ownerreference-1 -n $NAMESPACE
+                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-update-ownerreference-2 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/chainsaw-test.yaml
@@ -81,4 +81,3 @@ spec:
         - script:
             content: |
                 kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-update-ownerreference-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv4-update-ownerreference-2 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprange_1.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprange_1.yaml
@@ -2,16 +2,7 @@
 apiVersion: netbox.dev/v1
 kind: IpRange
 metadata:
-  annotations:
-    iprange.netbox.dev/managed-custom-fields: '{"netboxOperatorRestorationHash":"03cae1a8b295c77a1780a585b44562ed9a780807"}'
   name: iprangeclaim-ipv4-update-ownerreference-1
-  # ownerReferences:
-  #   - apiVersion: netbox.dev/v1
-  #     blockOwnerDeletion: true
-  #     controller: true
-  #     kind: IpRangeClaim
-  #     name: iprangeclaim-ipv4-update-ownerreference-1
-  #     uid: ad6815c2-fe29-4f37-9ecb-acfd1e7ab617
 spec:
   comments: your comments
   customFields:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprange_1.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprange_1.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: netbox.dev/v1
+kind: IpRange
+metadata:
+  annotations:
+    iprange.netbox.dev/managed-custom-fields: '{"netboxOperatorRestorationHash":"03cae1a8b295c77a1780a585b44562ed9a780807"}'
+  name: iprangeclaim-ipv4-update-ownerreference-1
+  # ownerReferences:
+  #   - apiVersion: netbox.dev/v1
+  #     blockOwnerDeletion: true
+  #     controller: true
+  #     kind: IpRangeClaim
+  #     name: iprangeclaim-ipv4-update-ownerreference-1
+  #     uid: ad6815c2-fe29-4f37-9ecb-acfd1e7ab617
+spec:
+  comments: your comments
+  customFields:
+    netboxOperatorRestorationHash: 03cae1a8b295c77a1780a585b44562ed9a780807
+  description: some description
+  endAddress: 3.2.4.30/32
+  startAddress: 3.2.4.1/32
+  tenant: MY_TENANT

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprange_1.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprange_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRange
 metadata:

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprangeclaim_1.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprangeclaim_1.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: netbox.dev/v1
+kind: IpRangeClaim
+metadata:
+  name: iprangeclaim-ipv4-update-ownerreference-1
+spec:
+  comments: your comments
+  description: some description
+  parentPrefix: 3.2.4.0/24
+  preserveInNetbox: false
+  tenant: MY_TENANT
+  size: 30

--- a/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprangeclaim_1.yaml
+++ b/tests/e2e/iprange/ipv4/iprangeclaim-ipv4-update-ownerreference/netbox_v1_iprangeclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-apply-update/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-apply-update/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -122,8 +121,8 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-apply-update -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-apply-update -n $NAMESPACE

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-apply-update/netbox_v1_iprangeclaim-update.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-apply-update/netbox_v1_iprangeclaim-update.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-apply-update/netbox_v1_iprangeclaim.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-apply-update/netbox_v1_iprangeclaim.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -128,7 +127,7 @@ spec:
                 size: 30
                 tenant: MY_TENANT
               status:
-                (conditions[?type == 'IPRangeAssigned']):  # TODO(jstudler): Change this to Ready, will need change in SetConditionAndCreateEvent to also update Ready condition
+                (conditions[?type == 'IPRangeAssigned']): # TODO(jstudler): Change this to Ready, will need change in SetConditionAndCreateEvent to also update Ready condition
                   - status: 'False'
         - assert:
             resource:
@@ -148,10 +147,10 @@ spec:
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-2 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-3 -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-prefixexhausted-3 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/netbox_v1_iprangeclaim_1.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/netbox_v1_iprangeclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/netbox_v1_iprangeclaim_2.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/netbox_v1_iprangeclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/netbox_v1_iprangeclaim_3.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-prefixexhausted/netbox_v1_iprangeclaim_3.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-restore/chainsaw-test.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-restore/chainsaw-test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -51,7 +50,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: 63e120bdabdb0f18598573f1c7f068e03bfcae62  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: 63e120bdabdb0f18598573f1c7f068e03bfcae62 # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 startAddress: 3:2:2::1/128
                 endAddress: 3:2:2::1e/128
@@ -163,7 +162,7 @@ spec:
               spec:
                 comments: your comments
                 customFields:
-                  netboxOperatorRestorationHash: 63e120bdabdb0f18598573f1c7f068e03bfcae62  # note that this will require the tests to run in the e2e namespace!
+                  netboxOperatorRestorationHash: 63e120bdabdb0f18598573f1c7f068e03bfcae62 # note that this will require the tests to run in the e2e namespace!
                 description: some description
                 startAddress: 3:2:2::1/128
                 endAddress: 3:2:2::1e/128
@@ -175,32 +174,32 @@ spec:
     - name: Set preserveInNetbox to false
       description: Set preserveInNetbox to false to clean up the NetBox test instance
       try:
-      - patch:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: IpRangeClaim
-            metadata:
-              name: iprangeclaim-ipv6-restore-1
-            spec:
-              preserveInNetbox: false
-      - assert:
-          resource:
-            apiVersion: netbox.dev/v1
-            kind: IpRange
-            metadata:
-              name: iprangeclaim-ipv6-restore-1
-            status:
-              (conditions[?type == 'Ready']):
-              - observedGeneration: 2
-                status: 'True'
+        - patch:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpRangeClaim
+              metadata:
+                name: iprangeclaim-ipv6-restore-1
+              spec:
+                preserveInNetbox: false
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: IpRange
+              metadata:
+                name: iprangeclaim-ipv6-restore-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - observedGeneration: 2
+                    status: 'True'
     - name: Cleanup events and leases
       description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource and lease cleanup for preventing delays when using the same prefixes (e.g. with "invalid" tests)
       cleanup:
         - script:
             content: |
-                LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
-                if [ -n "$LEASES" ]; then
-                  echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
-                fi
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-restore-1 -n $NAMESPACE
-                kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-restore-2 -n $NAMESPACE
+              LEASES=$(kubectl -n netbox-operator-system get lease -oname | grep -v netbox) # to be enhanced in usage of leaselocker
+              if [ -n "$LEASES" ]; then
+                echo "$LEASES" | xargs -n1 kubectl -n netbox-operator-system delete
+              fi
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-restore-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=iprangeclaim-ipv6-restore-2 -n $NAMESPACE

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-restore/netbox_v1_iprangeclaim_1.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-restore/netbox_v1_iprangeclaim_1.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-restore/netbox_v1_iprangeclaim_2.yaml
+++ b/tests/e2e/iprange/ipv6/iprangeclaim-ipv6-restore/netbox_v1_iprangeclaim_2.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: netbox.dev/v1
 kind: IpRangeClaim
 metadata:

--- a/tests/e2e/kind-config.yaml
+++ b/tests/e2e/kind-config.yaml
@@ -2,8 +2,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: kind
-
 nodes:
-- role: control-plane
-- role: worker
-- role: worker
+  - role: control-plane
+  - role: worker
+  - role: worker


### PR DESCRIPTION
A gap discovered in the backup and restore test was that the NetBox Operator child resources do not get the ownerReference set on Update. The goal of this PR is to make sure the IpAddressClaim, PrefixClaim and IpRangeClaim  controllers add the ownerReference to the IpAddress, Prefix and IpRange CR when it reconciles/updates them.