### PR TITLE
Change of NetBox Operator IpAddress short name to enhance UX in Kubernetes 1.33+

### DIFF
--- a/api/v1/ipaddress_types.go
+++ b/api/v1/ipaddress_types.go
@@ -88,7 +88,7 @@ type IpAddressStatus struct {
 //+kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.id`
 //+kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
-//+kubebuilder:resource:shortName=ip
+//+kubebuilder:resource:shortName=ipa
 
 // IpAddress allows to create a NetBox IP Address. More info about NetBox IP Addresses: https://github.com/netbox-community/netbox/blob/main/docs/models/ipam/ipaddress.md
 type IpAddress struct {

--- a/api/v1/ipaddressclaim_types.go
+++ b/api/v1/ipaddressclaim_types.go
@@ -89,7 +89,7 @@ type IpAddressClaimStatus struct {
 //+kubebuilder:printcolumn:name="IpAssigned",type=string,JSONPath=`.status.conditions[?(@.type=="IPAssigned")].status`
 //+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
-//+kubebuilder:resource:shortName=ipc
+//+kubebuilder:resource:shortName=ipac
 
 // IpAddressClaim allows to claim a NetBox IP Address from an existing Prefix.
 // The IpAddressClaim Controller will try to assign an available IP Address

--- a/config/crd/bases/netbox.dev_ipaddressclaims.yaml
+++ b/config/crd/bases/netbox.dev_ipaddressclaims.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: IpAddressClaimList
     plural: ipaddressclaims
     shortNames:
-    - ipc
+    - ipac
     singular: ipaddressclaim
   scope: Namespaced
   versions:

--- a/config/crd/bases/netbox.dev_ipaddresses.yaml
+++ b/config/crd/bases/netbox.dev_ipaddresses.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: IpAddressList
     plural: ipaddresses
     shortNames:
-    - ip
+    - ipa
     singular: ipaddress
   scope: Namespaced
   versions:


### PR DESCRIPTION
Changes the short names to enhance the user experience in Kubernetes 1.33+:

IpAddress from `ip` to `ipa` to prevent overlap with built in API for IPAddress that was introduced in [Kubernetes 1.33](https://github.com/kubernetes/kubernetes/compare/release-1.32...release-1.33#diff-fa35b3a0fe849544cc43eb5a8099cdab4a288d927244539b2d018021093553b5).
IpAddressClaim from `ipc` to `ipac` to be consistent with the above change and other NetBox Operator resources.

Fixes #374