### PR TITLE
Remove self-approval step from release workflow as it's not allowed i…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,8 +99,5 @@ jobs:
           PR_NUMBER=$(echo "$PR_URL" | sed 's/.*\/pull\///')
           echo "Created PR #$PR_NUMBER: $PR_URL"
 
-          # Auto-approve the PR
-          gh pr review "$PR_NUMBER" --approve --body "Auto-approving automated release PR"
-
           # Enable auto-merge and merge the PR
           gh pr merge "$PR_NUMBER" --auto --squash --delete-branch


### PR DESCRIPTION
 After having merge #407, we have seen that GitHub doesn't allow self-approval of reviews...

But in any case, branch protection doesn't require auto-approval and auto-merge will still work
