### PR TITLE
Adding app label to spec.selector

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,6 +16,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: thor-operator
   replicas: 1
   template:
     metadata:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-      app.kubernetes.io/name: thor-operator
+      app.kubernetes.io/name: netbox-operator
   replicas: 1
   template:
     metadata:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: netbox-operator
         app.kubernetes.io/part-of: netbox-operator
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression


### PR DESCRIPTION
Simple fix to add the `app.kubernetes.io/name: netbox-operator`  to the spec.selector so it can be used for filtering logs properly.