### PR TITLE
Fix: docker image tag after release

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -17,11 +17,14 @@ env:
 jobs:
   push:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     permissions:
       packages: write
       contents: read
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v5.0.0
+        with:
+          fetch-tags: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -33,6 +36,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get tag information
+        id: tag_info
+        run: |
+          LATEST_TAG=$(git tag --points-at HEAD || echo "no-tag")
+
+          # if LATEST_TAG is empty set it to "no-tag"
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="no-tag"
+          fi
+
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
       - name: Generate docker image tag
         id: meta
         uses: docker/metadata-action@v5.8.0
@@ -44,8 +58,8 @@ jobs:
             # (for all commits) generate a tag named sha-[short sha value]
             type=sha,enable=true
             # (for tagged commits only) generate tags identical to the git tag version, with and without the leading v
-            type=semver,pattern={{raw}},enable=${{startsWith(github.ref, 'refs/tags/v')}}
-            type=semver,pattern={{version}},enable=${{startsWith(github.ref, 'refs/tags/v')}}
+            type=semver,pattern={{raw}},enable=${{ steps.tag_info.outputs.latest_tag != 'no-tag' }},value=${{ steps.tag_info.outputs.latest_tag }}
+            type=semver,pattern={{version}},enable=${{ steps.tag_info.outputs.latest_tag != 'no-tag' }},value=${{ steps.tag_info.outputs.latest_tag }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -24,6 +24,7 @@ jobs:
   e2e-tests-3-7-8:
     name: Against netbox version 3.7.8
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -15,6 +15,7 @@ permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,7 @@ permissions: read-all
 jobs:
   go-and-crds:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0


### PR DESCRIPTION
read tag from git repo for image build after release
fetch tags in "build-image" workflow

In the tests the semver tags for the docker image show up: https://github.com/bruelea/netbox-operator/actions/runs/18125237458/job/51578850652#step:7:49