### PR TITLE
fix prefixLength regex pattern in prefixclaim

### DIFF
--- a/api/v1/prefixclaim_types.go
+++ b/api/v1/prefixclaim_types.go
@@ -45,7 +45,7 @@ type PrefixClaimSpec struct {
 	// Field is immutable, required
 	// Example: "/24"
 	//+kubebuilder:validation:Required
-	//+kubebuilder:validation:Pattern=`^\/[0-9]|[1-9][0-9]|1[01][0-9]|12[0-8]$`
+	//+kubebuilder:validation:Pattern=`^\/([0-9]|[1-9][0-9]|1[01][0-9]|12[0-8])$`
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="Field 'prefixLength' is immutable"
 	PrefixLength string `json:"prefixLength"`
 

--- a/config/crd/bases/netbox.dev_prefixclaims.yaml
+++ b/config/crd/bases/netbox.dev_prefixclaims.yaml
@@ -113,7 +113,7 @@ spec:
                   The desired prefix length of your Prefix using slash notation. Example: `/24` for an IPv4 Prefix or `/64` for an IPv6 Prefix
                   Field is immutable, required
                   Example: "/24"
-                pattern: ^\/[0-9]|[1-9][0-9]|1[01][0-9]|12[0-8]$
+                pattern: ^\/([0-9]|[1-9][0-9]|1[01][0-9]|12[0-8])$
                 type: string
                 x-kubernetes-validations:
                 - message: Field 'prefixLength' is immutable


### PR DESCRIPTION
The following was a prefixClaim accepted by kube-api. The regex needs brackets around the or statement so the startline and endline characters in the regex always apply.

```
---
apiVersion: netbox.dev/v1
kind: PrefixClaim
metadata:
  labels:
    app.kubernetes.io/name: netbox-operator
    app.kubernetes.io/managed-by: kustomize
  name: prefixclaim-sample
spec:
  tenant: "Dunder-Mifflin, Inc."
  site: "DM-Akron"
  description: "some description"
  comments: "your comments"
  preserveInNetbox: true
  parentPrefix: "2.0.0.0/16"
  prefixLength: "/222222222222222222222"
```