### PR TITLE
bump go to version 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/netbox-community/netbox-operator
 
 go 1.25
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
fixes GO-2025-4175 and GO-2025-4155