### PR TITLE
Disable NetBox Worker to improve e2e test stability

### DIFF
--- a/kind/deploy-netbox.sh
+++ b/kind/deploy-netbox.sh
@@ -204,6 +204,7 @@ ${HELM} upgrade --install netbox ${NETBOX_HELM_CHART} \
   --set resources.limits.memory="2Gi" \
   --set redis.image.repository="bitnamilegacy/redis" \
   --set global.security.allowInsecureImages=true \
+  --set worker.enabled=false \
     $REGISTRY_ARG
 
 if [[ "$FORCE_NETBOX_NGINX_IPV4" == "true" ]]; then


### PR DESCRIPTION
Sometimes the NetBox Worker pod blocks the main NetBox pod from becoming healthy. For the e2e tests of NetBox Operator, we don't rely on NetBox Workers and can thus disable it.