### PR TITLE
Provision IP address in NetBox based on LoadBalancer ingress IP

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -235,6 +235,13 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "IpRange")
 		os.Exit(1)
 	}
+	if err = (&controller.ServiceLoadBalancerReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ServiceLoadBalancer")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,14 @@ rules:
   - create
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - netbox.dev
   resources:
   - ipaddressclaims

--- a/internal/controller/service_loadbalancer_controller.go
+++ b/internal/controller/service_loadbalancer_controller.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2024 Swisscom (Schweiz) AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+
+	netboxv1 "github.com/netbox-community/netbox-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	serviceLoadBalancerManagedByLabel        = "netbox.dev/managed-by"
+	serviceLoadBalancerManagedByValue        = "service-loadbalancer"
+	serviceLoadBalancerServiceUIDLabel       = "netbox.dev/service-uid"
+	serviceLoadBalancerServiceNameLabel      = "netbox.dev/service-name"
+	serviceLoadBalancerServiceNamespaceLabel = "netbox.dev/service-namespace"
+)
+
+type ServiceLoadBalancerReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
+//+kubebuilder:rbac:groups=netbox.dev,resources=ipaddresses,verbs=get;list;watch;create;update;patch;delete
+
+func (r *ServiceLoadBalancerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	service := &corev1.Service{}
+	if err := r.Client.Get(ctx, req.NamespacedName, service); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return ctrl.Result{}, r.deleteManagedIpAddresses(ctx, service)
+	}
+
+	desiredIPs := serviceLoadBalancerIPs(service)
+	if len(desiredIPs) == 0 {
+		return ctrl.Result{}, r.deleteManagedIpAddresses(ctx, service)
+	}
+
+	desiredByAddress := make(map[string]struct{}, len(desiredIPs))
+	for _, ip := range desiredIPs {
+		desiredByAddress[ip] = struct{}{}
+		if err := r.ensureIpAddressCR(ctx, service, ip); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	existing := &netboxv1.IpAddressList{}
+	if err := r.Client.List(ctx, existing, client.InNamespace(service.Namespace), client.MatchingLabels(serviceLoadBalancerLabels(service))); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	for i := range existing.Items {
+		item := &existing.Items[i]
+		if _, ok := desiredByAddress[item.Spec.IpAddress]; ok {
+			continue
+		}
+		if err := r.Client.Delete(ctx, item); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		logger.Info("deleted stale ipaddress", "ipaddress", item.Name, "service", req.NamespacedName.String())
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ServiceLoadBalancerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Service{}).
+		Owns(&netboxv1.IpAddress{}).
+		Complete(r)
+}
+
+func (r *ServiceLoadBalancerReconciler) ensureIpAddressCR(ctx context.Context, service *corev1.Service, ipAddress string) error {
+	ipAddressResource := &netboxv1.IpAddress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceLoadBalancerIpAddressName(service.Name, ipAddress),
+			Namespace: service.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, ipAddressResource, func() error {
+		ipAddressResource.Spec = netboxv1.IpAddressSpec{
+			IpAddress:        ipAddress,
+			Description:      fmt.Sprintf("Service %s/%s", service.Namespace, service.Name),
+			PreserveInNetbox: false,
+		}
+		if ipAddressResource.Labels == nil {
+			ipAddressResource.Labels = map[string]string{}
+		}
+		for key, value := range serviceLoadBalancerLabels(service) {
+			ipAddressResource.Labels[key] = value
+		}
+		return controllerutil.SetControllerReference(service, ipAddressResource, r.Scheme)
+	})
+	return err
+}
+
+func (r *ServiceLoadBalancerReconciler) deleteManagedIpAddresses(ctx context.Context, service *corev1.Service) error {
+	list := &netboxv1.IpAddressList{}
+	if err := r.Client.List(ctx, list, client.InNamespace(service.Namespace), client.MatchingLabels(serviceLoadBalancerLabels(service))); err != nil {
+		return err
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		if err := r.Client.Delete(ctx, item); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func serviceLoadBalancerIPs(service *corev1.Service) []string {
+	var ips []string
+	for _, ingress := range service.Status.LoadBalancer.Ingress {
+		if ingress.IP == "" {
+			continue
+		}
+		ips = append(ips, normalizeIpAddress(ingress.IP))
+	}
+	return ips
+}
+
+func normalizeIpAddress(ip string) string {
+	if strings.Contains(ip, "/") {
+		return ip
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return ip
+	}
+	if parsed.To4() != nil {
+		return ip + "/32"
+	}
+	return ip + "/128"
+}
+
+func serviceLoadBalancerLabels(service *corev1.Service) map[string]string {
+	return map[string]string{
+		serviceLoadBalancerManagedByLabel:        serviceLoadBalancerManagedByValue,
+		serviceLoadBalancerServiceUIDLabel:       string(service.UID),
+		serviceLoadBalancerServiceNameLabel:      service.Name,
+		serviceLoadBalancerServiceNamespaceLabel: service.Namespace,
+	}
+}
+
+func serviceLoadBalancerIpAddressName(serviceName, ipAddress string) string {
+	hash := sha1.Sum([]byte(ipAddress))
+	return fmt.Sprintf("%s-%s", serviceName, hex.EncodeToString(hash[:4]))
+}

--- a/internal/controller/service_loadbalancer_controller_test.go
+++ b/internal/controller/service_loadbalancer_controller_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 Swisscom (Schweiz) AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	"github.com/netbox-community/go-netbox/v3/netbox/client/ipam"
+	netboxModels "github.com/netbox-community/go-netbox/v3/netbox/models"
+	"github.com/netbox-community/netbox-operator/gen/mock_interfaces"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	netboxv1 "github.com/netbox-community/netbox-operator/api/v1"
+)
+
+var _ = Describe("Service LoadBalancer Controller", Ordered, func() {
+	const timeout = time.Second * 4
+	const interval = time.Millisecond * 250
+
+	BeforeEach(func() {
+		allowIpAddressNetboxCalls(ipamMockIpAddress)
+	})
+
+	AfterEach(func() {
+		resetMockFunctions(ipamMockIpAddress, ipamMockIpAddressClaim, tenancyMock)
+	})
+
+	It("creates and prunes IpAddress CRs for LoadBalancer services", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "lb-service",
+				Namespace: namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{Port: 80},
+				},
+			},
+		}
+
+		By("Creating a load balancer service")
+		Eventually(k8sClient.Create(ctx, service), timeout, interval).Should(Succeed())
+
+		By("Adding ingress IPs to service status")
+		Eventually(func() error {
+			latest := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, latest); err != nil {
+				return err
+			}
+			latest.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+				{IP: "1.0.0.1"},
+				{IP: "1.0.0.2"},
+			}
+			return k8sClient.Status().Update(ctx, latest)
+		}, timeout, interval).Should(Succeed())
+
+		By("Refreshing service metadata for label matching")
+		Eventually(func() error {
+			latest := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, latest); err != nil {
+				return err
+			}
+			service = latest
+			return nil
+		}, timeout, interval).Should(Succeed())
+
+		By("Ensuring ipaddress CRs are created for both IPs")
+		Eventually(func() ([]string, error) {
+			list := &netboxv1.IpAddressList{}
+			if err := k8sClient.List(ctx, list, client.InNamespace(service.Namespace), client.MatchingLabels(serviceLoadBalancerLabels(service))); err != nil {
+				return nil, err
+			}
+			ipAddresses := make([]string, 0, len(list.Items))
+			for _, item := range list.Items {
+				ipAddresses = append(ipAddresses, item.Spec.IpAddress)
+			}
+			return ipAddresses, nil
+		}, timeout, interval).Should(ConsistOf("1.0.0.1/32", "1.0.0.2/32"))
+
+		By("Removing one ingress IP and pruning the stale ipaddress")
+		Eventually(func() error {
+			latest := &corev1.Service{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, latest); err != nil {
+				return err
+			}
+			latest.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+				{IP: "1.0.0.1"},
+			}
+			return k8sClient.Status().Update(ctx, latest)
+		}, timeout, interval).Should(Succeed())
+
+		Eventually(func() ([]string, error) {
+			list := &netboxv1.IpAddressList{}
+			if err := k8sClient.List(ctx, list, client.InNamespace(service.Namespace), client.MatchingLabels(serviceLoadBalancerLabels(service))); err != nil {
+				return nil, err
+			}
+			ipAddresses := make([]string, 0, len(list.Items))
+			for _, item := range list.Items {
+				ipAddresses = append(ipAddresses, item.Spec.IpAddress)
+			}
+			return ipAddresses, nil
+		}, timeout, interval).Should(ConsistOf("1.0.0.1/32"))
+
+		By("Cleaning up the service")
+		Expect(k8sClient.Delete(ctx, service)).To(Succeed())
+
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, &corev1.Service{})
+			return apierrors.IsNotFound(err)
+		}, timeout, interval).Should(BeTrue())
+	})
+})
+
+func allowIpAddressNetboxCalls(ipamMock *mock_interfaces.MockIpamInterface) {
+	ipamMock.EXPECT().IpamIPAddressesList(gomock.Any(), gomock.Any()).
+		Return(&ipam.IpamIPAddressesListOK{Payload: mockedResponseEmptyIPAddressList()}, nil).
+		AnyTimes()
+	ipamMock.EXPECT().IpamIPAddressesCreate(gomock.Any(), nil).
+		Return(&ipam.IpamIPAddressesCreateCreated{Payload: mockedResponseIPAddress()}, nil).
+		AnyTimes()
+	ipamMock.EXPECT().IpamIPAddressesDelete(gomock.Any(), nil).
+		Return(&ipam.IpamIPAddressesDeleteNoContent{}, nil).
+		AnyTimes()
+	ipamMock.EXPECT().IpamIPAddressesUpdate(gomock.Any(), nil).
+		Return(&ipam.IpamIPAddressesUpdateOK{Payload: &netboxModels.IPAddress{ID: 1}}, nil).
+		AnyTimes()
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -145,6 +145,12 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&ServiceLoadBalancerReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		ctx, cancel = context.WithCancel(context.TODO())


### PR DESCRIPTION
Add a new controller that tracks LoadBalancer Services and keeps matching NetBox `IPAddress` CRs in sync.