### PR TITLE
Add scheduled reconciliation to all controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
+	github.com/robfig/cron/v3 v3.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/netbox-community/netbox-operator
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3
@@ -17,6 +17,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/pkg/errors v0.9.1
+	github.com/robfig/cron/v3 v3.0.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -86,7 +87,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
-	github.com/robfig/cron/v3 v3.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -30,6 +30,8 @@ import (
 	"github.com/netbox-community/netbox-operator/pkg/config"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/api"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/models"
+	"github.com/netbox-community/netbox-operator/pkg/scheduler"
+
 	"github.com/swisscom/leaselocker"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -79,14 +81,18 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// merge-patch diff captures every change (IpAddressId, conditions, etc.).
 	statusBase := o.DeepCopy()
 
-	// cancelLock stops the lease renewal goroutine on early returns (lease expires naturally).
-	// Explicit cancelLock()+UnlockWithRetry() runs inline after the critical section.
-	var cancelLock context.CancelFunc
-
 	// Defer status update to ensure it happens regardless of how we exit
 	defer func() {
 		reconcileResult, reconcileErr = r.updateStatus(ctx, o, statusBase, reconcileResult, reconcileErr)
+		if reconcileErr == nil && reconcileResult.IsZero() {
+			reconcileResult, reconcileErr = scheduler.CalculateNextReconcile(ctx)
+		}
+		logger.Info("reconcile loop finished")
 	}()
+
+	// cancelLock stops the lease renewal goroutine on early returns (lease expires naturally).
+	// Explicit cancelLock()+UnlockWithRetry() runs inline after the critical section.
+	var cancelLock context.CancelFunc
 
 	// if being deleted
 	if !o.DeletionTimestamp.IsZero() {

--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -84,8 +84,19 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Defer status update to ensure it happens regardless of how we exit
 	defer func() {
 		reconcileResult, reconcileErr = r.updateStatus(ctx, o, statusBase, reconcileResult, reconcileErr)
+		logger.Info("evaluating scheduled reconciliation",
+			"hasError", reconcileErr != nil,
+			"isZeroResult", reconcileResult.IsZero(),
+			"requeueAfter", reconcileResult.RequeueAfter.String())
 		if reconcileErr == nil && reconcileResult.IsZero() {
 			reconcileResult, reconcileErr = scheduler.CalculateNextReconcile(ctx)
+			logger.Info("scheduled reconciliation evaluation finished",
+				"isZeroResult", reconcileResult.IsZero(),
+				"requeueAfter", reconcileResult.RequeueAfter.String(),
+				"hasError", reconcileErr != nil)
+		} else {
+			logger.Info("scheduled reconciliation skipped",
+				"reason", "reconcile had error or already requested requeue")
 		}
 		logger.Info("reconcile loop finished")
 	}()

--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -84,19 +84,8 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Defer status update to ensure it happens regardless of how we exit
 	defer func() {
 		reconcileResult, reconcileErr = r.updateStatus(ctx, o, statusBase, reconcileResult, reconcileErr)
-		logger.Info("evaluating scheduled reconciliation",
-			"hasError", reconcileErr != nil,
-			"isZeroResult", reconcileResult.IsZero(),
-			"requeueAfter", reconcileResult.RequeueAfter.String())
 		if reconcileErr == nil && reconcileResult.IsZero() {
 			reconcileResult, reconcileErr = scheduler.CalculateNextReconcile(ctx)
-			logger.Info("scheduled reconciliation evaluation finished",
-				"isZeroResult", reconcileResult.IsZero(),
-				"requeueAfter", reconcileResult.RequeueAfter.String(),
-				"hasError", reconcileErr != nil)
-		} else {
-			logger.Info("scheduled reconciliation skipped",
-				"reason", "reconcile had error or already requested requeue")
 		}
 		logger.Info("reconcile loop finished")
 	}()

--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -189,7 +189,6 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	logger.Info("reconcile loop finished")
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -26,6 +26,8 @@ import (
 	netboxv1 "github.com/netbox-community/netbox-operator/api/v1"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/api"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/models"
+	"github.com/netbox-community/netbox-operator/pkg/scheduler"
+
 	"github.com/swisscom/leaselocker"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +83,10 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// The deferred function captures the return values to include error context in status
 	defer func() {
 		reconcileResult, reconcileErr = r.updateStatus(ctx, o, statusBase, req.NamespacedName, reconcileResult, reconcileErr)
+		if reconcileErr == nil && reconcileResult.IsZero() {
+			reconcileResult, reconcileErr = scheduler.CalculateNextReconcile(ctx)
+		}
+		logger.Info("reconcile loop finished")
 	}()
 
 	// 1. check if matching IpAddress object already exists

--- a/internal/controller/iprange_controller.go
+++ b/internal/controller/iprange_controller.go
@@ -31,6 +31,8 @@ import (
 	"github.com/netbox-community/netbox-operator/pkg/config"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/api"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/models"
+	"github.com/netbox-community/netbox-operator/pkg/scheduler"
+
 	"github.com/swisscom/leaselocker"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -83,6 +85,10 @@ func (r *IpRangeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// Defer status update to ensure it happens regardless of how we exit
 	defer func() {
 		reconcileResult, reconcileErr = r.updateStatus(ctx, o, statusBase, reconcileResult, reconcileErr)
+		if reconcileErr == nil && reconcileResult.IsZero() {
+			reconcileResult, reconcileErr = scheduler.CalculateNextReconcile(ctx)
+		}
+		logger.Info("reconcile loop finished")
 	}()
 
 	// if being deleted

--- a/internal/controller/iprange_controller.go
+++ b/internal/controller/iprange_controller.go
@@ -225,8 +225,6 @@ func (r *IpRangeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		o.Status.LastUpdated = metav1.NewTime(*netboxIpRangeModel.LastUpdated.Get())
 	}
 
-	logger.Info("reconcile loop finished")
-
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/iprangeclaim_controller.go
+++ b/internal/controller/iprangeclaim_controller.go
@@ -26,6 +26,8 @@ import (
 	netboxv1 "github.com/netbox-community/netbox-operator/api/v1"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/api"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/models"
+	"github.com/netbox-community/netbox-operator/pkg/scheduler"
+
 	"github.com/swisscom/leaselocker"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -101,6 +103,10 @@ func (r *IpRangeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Defer status update to ensure it happens regardless of how we exit
 	defer func() {
 		reconcileResult, reconcileErr = r.updateStatus(ctx, o, statusBase, ipRangeLookupKey, reconcileResult, reconcileErr)
+		if reconcileErr == nil && reconcileResult.IsZero() {
+			reconcileResult, reconcileErr = scheduler.CalculateNextReconcile(ctx)
+		}
+		logger.Info("reconcile loop finished")
 	}()
 
 	err = r.Get(ctx, ipRangeLookupKey, ipRange)

--- a/internal/controller/iprangeclaim_controller.go
+++ b/internal/controller/iprangeclaim_controller.go
@@ -157,7 +157,6 @@ func (r *IpRangeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	logger.Info("reconcile loop finished")
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/prefix_controller.go
+++ b/internal/controller/prefix_controller.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/netbox-community/netbox-operator/pkg/config"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/models"
+	"github.com/netbox-community/netbox-operator/pkg/scheduler"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismeta "k8s.io/apimachinery/pkg/api/meta"
@@ -83,6 +85,10 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rec
 	// Defer status update to ensure it happens regardless of how we exit
 	defer func() {
 		reconcileResult, reconcileErr = r.updateStatus(ctx, o, statusBase, reconcileResult, reconcileErr)
+		if reconcileErr == nil && reconcileResult.IsZero() {
+			reconcileResult, reconcileErr = scheduler.CalculateNextReconcile(ctx)
+		}
+		logger.Info("reconcile loop finished")
 	}()
 
 	// if being deleted

--- a/internal/controller/prefix_controller.go
+++ b/internal/controller/prefix_controller.go
@@ -263,8 +263,6 @@ func (r *PrefixReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rec
 
 	logger.V(4).Info(fmt.Sprintf("reserved prefix in netbox, prefix: %s", o.Spec.Prefix))
 
-	logger.Info("reconcile loop finished")
-
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/netbox-community/netbox-operator/pkg/netbox/models"
+	"github.com/netbox-community/netbox-operator/pkg/scheduler"
+
 	"github.com/swisscom/leaselocker"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -84,6 +86,10 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Defer status update to ensure it happens regardless of how we exit
 	defer func() {
 		reconcileResult, reconcileErr = r.updateStatus(ctx, o, statusBase, req.NamespacedName, reconcileResult, reconcileErr)
+		if reconcileErr == nil && reconcileResult.IsZero() {
+			reconcileResult, reconcileErr = scheduler.CalculateNextReconcile(ctx)
+		}
+		logger.Info("reconcile loop finished")
 	}()
 
 	/* 1. compute and assign the parent prefix if required */

--- a/internal/controller/prefixclaim_controller.go
+++ b/internal/controller/prefixclaim_controller.go
@@ -297,8 +297,6 @@ func (r *PrefixClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	logger.Info("reconcile loop finished")
-
 	return ctrl.Result{}, nil
 }
 

--- a/kind/kustomization.yaml
+++ b/kind/kustomization.yaml
@@ -32,3 +32,8 @@ patches:
               - name: netbox-auth
                 secret:
                   secretName: netbox-auth
+# Uncomment the patch to enable scheduled reconciliation
+  - path: scheduled-reconcile-patch.yaml
+    target:
+      kind: Deployment
+      labelSelector: "app.kubernetes.io/part-of=netbox-operator"

--- a/kind/kustomization.yaml
+++ b/kind/kustomization.yaml
@@ -32,7 +32,7 @@ patches:
               - name: netbox-auth
                 secret:
                   secretName: netbox-auth
-# Uncomment the patch to enable scheduled reconciliation
+  # Uncomment the patch to enable scheduled reconciliation
   - path: scheduled-reconcile-patch.yaml
     target:
       kind: Deployment

--- a/kind/scheduled-reconcile-patch.yaml
+++ b/kind/scheduled-reconcile-patch.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: netbox-operator-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: "RECONCILE_SCHEDULE"
+              value: "30 13 * * *" # if no schedule is defined scheduled reconciliation is disabled
+            - name: "RECONCILE_JITTER"
+              value: "60m" # defaults to 1h if empty

--- a/kind/scheduled-reconcile-patch.yaml
+++ b/kind/scheduled-reconcile-patch.yaml
@@ -11,6 +11,6 @@ spec:
         - name: manager
           env:
             - name: "RECONCILE_SCHEDULE"
-              value: "30 13 * * *" # if no schedule is defined scheduled reconciliation is disabled
+              value: "50 5 * * *" # if no schedule is defined scheduled reconciliation is disabled
             - name: "RECONCILE_JITTER"
-              value: "60m" # defaults to 1h if empty
+              value: "10m" # defaults to 1h if empty

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -142,6 +142,10 @@ func (c *OperatorConfig) parseScheduleAndJitter() (err error) {
 		if err != nil {
 			return fmt.Errorf("invalid reconcile jitter %q: %w", c.ReconcileJitterRaw, err)
 		}
+
+		if c.ReconcileJitterDuration < 0 {
+			return fmt.Errorf("invalid reconcile jitter %q: must be greater than or equal to 0", c.ReconcileJitterRaw)
+		}
 	}
 
 	// Parse cron schedule

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Swisscom (Schweiz) AG.
+Copyright 2026 Swisscom (Schweiz) AG.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -155,6 +155,12 @@ func (c *OperatorConfig) parseScheduleAndJitter() (err error) {
 		if err != nil {
 			return fmt.Errorf("invalid cron schedule %q: %w", c.ReconcileScheduleRaw, err)
 		}
+
+		log.Printf("Scheduled reconciliation enabled: schedule=%s, jitter=%s",
+			c.ReconcileScheduleRaw,
+			c.ReconcileJitterDuration.String())
+	} else {
+		log.Printf("Scheduled reconciliation disabled: no reconcile schedule configured")
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,10 +21,13 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"sync"
+	"time"
 
+	"github.com/robfig/cron/v3"
 	"github.com/spf13/viper"
 )
 
@@ -38,6 +41,23 @@ type OperatorConfig struct {
 	HttpsEnable                    bool   `mapstructure:"HTTPS_ENABLE"`
 	DebugEnable                    bool   `mapstructure:"DEBUG_ENABLE"`
 	NetboxRestorationHashFieldName string `mapstructure:"NETBOX_RESTORATION_HASH_FIELD_NAME"`
+
+	// cron schedule for scheduled reconciliation of all custom resources
+	// if set, all custom resources will be reconciled at the defined schedule, in addition to the regular event-based reconciliation
+	// if empty, scheduled reconciliation is disabled
+	// format: cron, see https://pkg.go.dev/github.com/robfig/cron/v3 for examples
+	// defaults to empty (disabled)
+	ReconcileScheduleRaw string `mapstructure:"RECONCILE_SCHEDULE"`
+	// jitter which is added to the defined reconcile schedule, only used if RECONCILE_SCHEDULE is defined
+	// it adds a random amount of time within a given window to the next scheduled reconcile and can help reducing load on backend systems
+	// all reconciles are randomly distributed across the window [scheduled trigger time, scheduled trigger time + RECONCILE_JITTER]
+	// format: duration, needs to be parseable by time.ParseDuration, e.g. "30s", "30m"
+	// defaults to 1 hour
+	ReconcileJitterRaw string `mapstructure:"RECONCILE_JITTER"`
+
+	// Parsed fields (not from config file/env)
+	ReconcileSchedule       cron.Schedule
+	ReconcileJitterDuration time.Duration
 }
 
 func (c *OperatorConfig) setDefaults() {
@@ -47,6 +67,10 @@ func (c *OperatorConfig) setDefaults() {
 	c.viper.SetDefault("HTTPS_ENABLE", true)
 	c.viper.SetDefault("DEBUG_ENABLE", false)
 	c.viper.SetDefault("NETBOX_RESTORATION_HASH_FIELD_NAME", "netboxOperatorRestorationHash")
+
+	c.viper.SetDefault("RECONCILE_JITTER", "")
+	c.viper.SetDefault("RECONCILE_SCHEDULE", "")
+
 }
 
 func (c *OperatorConfig) LoadCaCert() (cert []byte, err error) {
@@ -87,6 +111,12 @@ func GetOperatorConfig() *OperatorConfig {
 			return
 		}
 
+		err = c.parseScheduleAndJitter()
+		if err != nil {
+			log.Fatalf("error parsing schedule and jitter: %s", err)
+			return
+		}
+
 		configuration = c
 	})
 
@@ -102,4 +132,40 @@ func GetProtocol() string {
 
 func GetBaseUrl() string {
 	return GetProtocol() + "://" + GetOperatorConfig().NetboxHost
+}
+
+func (c *OperatorConfig) parseScheduleAndJitter() (err error) {
+	// Parse jitter duration
+	c.ReconcileJitterDuration = time.Hour // default
+	if c.ReconcileJitterRaw != "" {
+		c.ReconcileJitterDuration, err = time.ParseDuration(c.ReconcileJitterRaw)
+		if err != nil {
+			return fmt.Errorf("invalid reconcile jitter %q: %w", c.ReconcileJitterRaw, err)
+		}
+	}
+
+	// Parse cron schedule
+	c.ReconcileSchedule = nil // default
+	if c.ReconcileScheduleRaw != "" {
+		c.ReconcileSchedule, err = parseCronSchedule(c.ReconcileScheduleRaw)
+		if err != nil {
+			return fmt.Errorf("invalid cron schedule %q: %w", c.ReconcileScheduleRaw, err)
+		}
+	}
+
+	return nil
+}
+
+func parseCronSchedule(cronExpr string) (cron.Schedule, error) {
+	schedule, err := cron.ParseStandard(cronExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	return schedule, nil
+}
+
+func ResetForTesting() {
+	once = sync.Once{}
+	configuration = nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,7 +149,6 @@ func (c *OperatorConfig) parseScheduleAndJitter() (err error) {
 	}
 
 	// Parse cron schedule
-	c.ReconcileSchedule = nil // default
 	if c.ReconcileScheduleRaw != "" {
 		c.ReconcileSchedule, err = parseCronSchedule(c.ReconcileScheduleRaw)
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Swisscom (Schweiz) AG.
+Copyright 2026 Swisscom (Schweiz) AG.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,9 +1,22 @@
-//go:build unit
+/*
+Copyright 2024 Swisscom (Schweiz) AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package config
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -11,18 +24,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	filePath   = "."
-	fileName   = "test"
-	fileFormat = "env"
-)
-
 func TestLoadConfigFromEnv(t *testing.T) {
-	os.Setenv("NETBOX_HOST", "netbox_host")
-	os.Setenv("AUTH_TOKEN", "auth-token")
-
-	os.Setenv("RECONCILE_JITTER", "30m")
-	os.Setenv("RECONCILE_SCHEDULE", "0 2 * * *")
+	t.Setenv("NETBOX_HOST", "netbox_host")
+	t.Setenv("AUTH_TOKEN", "auth-token")
+	t.Setenv("RECONCILE_JITTER", "30m")
+	t.Setenv("RECONCILE_SCHEDULE", "0 2 * * *")
+	ResetForTesting()
 
 	configuration := GetOperatorConfig()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,7 +5,9 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
+	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,8 +21,63 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	os.Setenv("NETBOX_HOST", "netbox_host")
 	os.Setenv("AUTH_TOKEN", "auth-token")
 
+	os.Setenv("RECONCILE_JITTER", "30m")
+	os.Setenv("RECONCILE_SCHEDULE", "0 2 * * *")
+
 	configuration := GetOperatorConfig()
+
+	expectedSchedule, _ := cron.ParseStandard("0 2 * * *")
 
 	assert.Equal(t, "netbox_host", configuration.NetboxHost)
 	assert.Equal(t, "auth-token", configuration.AuthToken)
+
+	assert.Equal(t, 30*time.Minute, configuration.ReconcileJitterDuration)
+	assert.Equal(t, configuration.ReconcileSchedule, expectedSchedule)
+
+}
+
+func TestParseScheduleAndJitter_Defaults(t *testing.T) {
+	c := &OperatorConfig{
+		ReconcileJitterRaw:   "",
+		ReconcileScheduleRaw: "",
+	}
+	err := c.parseScheduleAndJitter()
+	assert.NoError(t, err)
+	assert.Equal(t, time.Hour, c.ReconcileJitterDuration)
+	assert.Equal(t, nil, c.ReconcileSchedule)
+}
+
+func TestParseScheduleAndJitter_CustomValues(t *testing.T) {
+	c := &OperatorConfig{
+		ReconcileJitterRaw:   "30m",
+		ReconcileScheduleRaw: "0 2 * * *",
+	}
+	expectedSchedule, _ := cron.ParseStandard("0 2 * * *")
+	err := c.parseScheduleAndJitter()
+	assert.NoError(t, err)
+	assert.Equal(t, 30*time.Minute, c.ReconcileJitterDuration)
+	assert.Equal(t, expectedSchedule, c.ReconcileSchedule)
+}
+
+func TestParseScheduleAndJitter_InvalidJitter(t *testing.T) {
+	c := &OperatorConfig{
+		ReconcileJitterRaw: "notaduration",
+	}
+	err := c.parseScheduleAndJitter()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid reconcile jitter")
+}
+
+func TestParseScheduleAndJitter_InvalidSchedule(t *testing.T) {
+	c := &OperatorConfig{
+		ReconcileScheduleRaw: "bad cron",
+	}
+	err := c.parseScheduleAndJitter()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid cron schedule")
+}
+
+func TestParseCronSchedule_InvalidHour(t *testing.T) {
+	_, err := parseCronSchedule("0 xx * * *")
+	assert.Error(t, err)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 Swisscom (Schweiz) AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package scheduler contains scheduled reconciliation logic.
+*/
+package scheduler
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/netbox-community/netbox-operator/pkg/config"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func CalculateNextReconcile(ctx context.Context) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// do not reschedule if no schedule is defined
+	if config.GetOperatorConfig().ReconcileSchedule == nil {
+		return ctrl.Result{}, nil
+	}
+
+	// Calculate duration till next reconciliation and add jitter
+	jitter := getJitterDuration()
+	nextRunWithJitter := time.Until(config.GetOperatorConfig().ReconcileSchedule.Next(time.Now())) + jitter
+
+	if nextRunWithJitter > 0 {
+		logger.V(4).Info("Scheduled next reconciliation",
+			"after", nextRunWithJitter.String(),
+			"jitter", jitter.String())
+	}
+
+	return ctrl.Result{RequeueAfter: nextRunWithJitter}, nil
+}
+
+func getJitterDuration() time.Duration {
+	if config.GetOperatorConfig().ReconcileJitterDuration == 0 {
+		return 0
+	}
+
+	return time.Duration(rand.Int63n(
+		int64(config.GetOperatorConfig().ReconcileJitterDuration),
+	))
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -46,7 +46,7 @@ func CalculateNextReconcile(ctx context.Context) (ctrl.Result, error) {
 	}
 
 	if nextRunWithJitter > 0 {
-		logger.V(1).Info("Scheduled next reconciliation",
+		logger.V(4).Info("Scheduled next reconciliation",
 			"after", nextRunWithJitter.String(),
 			"jitter", jitter.String())
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Swisscom (Schweiz) AG.
+Copyright 2026 Swisscom (Schweiz) AG.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ func CalculateNextReconcile(ctx context.Context) (ctrl.Result, error) {
 
 	// do not reschedule if no schedule is defined
 	if config.GetOperatorConfig().ReconcileSchedule == nil {
-		logger.Info("Scheduled reconciliation disabled: no reconcile schedule configured")
 		return ctrl.Result{}, nil
 	}
 
@@ -46,11 +45,8 @@ func CalculateNextReconcile(ctx context.Context) (ctrl.Result, error) {
 		nextRunWithJitter = 0
 	}
 
-	logger.Info("Calculated next reconciliation delay",
-		"nextRunWithJitter", nextRunWithJitter.String())
-
 	if nextRunWithJitter > 0 {
-		logger.Info("Scheduled next reconciliation",
+		logger.V(1).Info("Scheduled next reconciliation",
 			"after", nextRunWithJitter.String(),
 			"jitter", jitter.String())
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -34,15 +34,23 @@ func CalculateNextReconcile(ctx context.Context) (ctrl.Result, error) {
 
 	// do not reschedule if no schedule is defined
 	if config.GetOperatorConfig().ReconcileSchedule == nil {
+		logger.Info("Scheduled reconciliation disabled: no reconcile schedule configured")
 		return ctrl.Result{}, nil
 	}
 
 	// Calculate duration till next reconciliation and add jitter
 	jitter := getJitterDuration()
-	nextRunWithJitter := time.Until(config.GetOperatorConfig().ReconcileSchedule.Next(time.Now())) + jitter
+	now := time.Now()
+	nextRunWithJitter := config.GetOperatorConfig().ReconcileSchedule.Next(now).Sub(now) + jitter
+	if nextRunWithJitter < 0 {
+		nextRunWithJitter = 0
+	}
+
+	logger.Info("Calculated next reconciliation delay",
+		"nextRunWithJitter", nextRunWithJitter.String())
 
 	if nextRunWithJitter > 0 {
-		logger.V(4).Info("Scheduled next reconciliation",
+		logger.Info("Scheduled next reconciliation",
 			"after", nextRunWithJitter.String(),
 			"jitter", jitter.String())
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Swisscom (Schweiz) AG.
+Copyright 2026 Swisscom (Schweiz) AG.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 Swisscom (Schweiz) AG.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/netbox-community/netbox-operator/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateNextReconcile_PositiveSchedule(t *testing.T) {
+	config.ResetForTesting()
+
+	os.Setenv("NETBOX_HOST", "netbox_host")
+	os.Setenv("AUTH_TOKEN", "auth-token")
+	os.Setenv("RECONCILE_JITTER", "10s")
+	os.Setenv("RECONCILE_SCHEDULE", "*/2 * * * *")
+
+	maxJitter := config.GetOperatorConfig().ReconcileJitterDuration
+
+	ctx := context.Background()
+	result, err := CalculateNextReconcile(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter > 2*time.Minute+maxJitter {
+		t.Errorf("unexpected RequeueAfter: got %v, want between 0 min and 2 min 10 seconds", result.RequeueAfter)
+	}
+}
+
+func TestCalculateNextReconcile_ZeroSchedule(t *testing.T) {
+	config.ResetForTesting()
+
+	os.Setenv("NETBOX_HOST", "netbox_host")
+	os.Setenv("AUTH_TOKEN", "auth-token")
+	os.Setenv("RECONCILE_JITTER", "1s")
+	os.Setenv("RECONCILE_SCHEDULE", "")
+
+	schedule := config.GetOperatorConfig().ReconcileSchedule
+	if schedule != nil {
+		t.Fatalf("expected empty schedule but got %v", schedule)
+	}
+
+	ctx := context.Background()
+	result, err := CalculateNextReconcile(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.True(t, result.IsZero())
+}
+
+func TestCalculateNextReconcile_ZeroJitter(t *testing.T) {
+	config.ResetForTesting()
+
+	os.Setenv("NETBOX_HOST", "netbox_host")
+	os.Setenv("AUTH_TOKEN", "auth-token")
+	// if empty jitter will be set to the default of 1 hour
+	os.Setenv("RECONCILE_JITTER", "")
+	os.Setenv("RECONCILE_SCHEDULE", "0 */2 * * *")
+
+	next := config.GetOperatorConfig().ReconcileSchedule.Next(time.Now())
+
+	ctx := context.Background()
+	result, err := CalculateNextReconcile(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter > 2*time.Hour+1*time.Hour {
+		t.Errorf("unexpected RequeueAfter: got %v, want 2m (next: %v)", result.RequeueAfter, next)
+	}
+}
+
+func TestGetJitterDuration_Range(t *testing.T) {
+	config.ResetForTesting()
+
+	os.Setenv("NETBOX_HOST", "netbox_host")
+	os.Setenv("AUTH_TOKEN", "auth-token")
+	os.Setenv("RECONCILE_JITTER", "5s")
+
+	maxJitter := config.GetOperatorConfig().ReconcileJitterDuration
+
+	for i := 0; i < 10; i++ {
+		jitter := getJitterDuration()
+		if jitter < 0 || jitter >= 5*time.Second {
+			t.Errorf("jitter out of range: got %v, want between 0 s  and %v", jitter, maxJitter)
+		}
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -18,7 +18,6 @@ package scheduler
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -27,12 +26,11 @@ import (
 )
 
 func TestCalculateNextReconcile_PositiveSchedule(t *testing.T) {
+	t.Setenv("NETBOX_HOST", "netbox_host")
+	t.Setenv("AUTH_TOKEN", "auth-token")
+	t.Setenv("RECONCILE_JITTER", "10s")
+	t.Setenv("RECONCILE_SCHEDULE", "*/2 * * * *")
 	config.ResetForTesting()
-
-	os.Setenv("NETBOX_HOST", "netbox_host")
-	os.Setenv("AUTH_TOKEN", "auth-token")
-	os.Setenv("RECONCILE_JITTER", "10s")
-	os.Setenv("RECONCILE_SCHEDULE", "*/2 * * * *")
 
 	maxJitter := config.GetOperatorConfig().ReconcileJitterDuration
 
@@ -47,12 +45,11 @@ func TestCalculateNextReconcile_PositiveSchedule(t *testing.T) {
 }
 
 func TestCalculateNextReconcile_ZeroSchedule(t *testing.T) {
+	t.Setenv("NETBOX_HOST", "netbox_host")
+	t.Setenv("AUTH_TOKEN", "auth-token")
+	t.Setenv("RECONCILE_JITTER", "1s")
+	t.Setenv("RECONCILE_SCHEDULE", "")
 	config.ResetForTesting()
-
-	os.Setenv("NETBOX_HOST", "netbox_host")
-	os.Setenv("AUTH_TOKEN", "auth-token")
-	os.Setenv("RECONCILE_JITTER", "1s")
-	os.Setenv("RECONCILE_SCHEDULE", "")
 
 	schedule := config.GetOperatorConfig().ReconcileSchedule
 	if schedule != nil {
@@ -67,14 +64,13 @@ func TestCalculateNextReconcile_ZeroSchedule(t *testing.T) {
 	assert.True(t, result.IsZero())
 }
 
-func TestCalculateNextReconcile_ZeroJitter(t *testing.T) {
-	config.ResetForTesting()
-
-	os.Setenv("NETBOX_HOST", "netbox_host")
-	os.Setenv("AUTH_TOKEN", "auth-token")
+func TestCalculateNextReconcile_DefaultJitterWhenEmpty(t *testing.T) {
+	t.Setenv("NETBOX_HOST", "netbox_host")
+	t.Setenv("AUTH_TOKEN", "auth-token")
 	// if empty jitter will be set to the default of 1 hour
-	os.Setenv("RECONCILE_JITTER", "")
-	os.Setenv("RECONCILE_SCHEDULE", "0 */2 * * *")
+	t.Setenv("RECONCILE_JITTER", "")
+	t.Setenv("RECONCILE_SCHEDULE", "0 */2 * * *")
+	config.ResetForTesting()
 
 	next := config.GetOperatorConfig().ReconcileSchedule.Next(time.Now())
 
@@ -89,11 +85,10 @@ func TestCalculateNextReconcile_ZeroJitter(t *testing.T) {
 }
 
 func TestGetJitterDuration_Range(t *testing.T) {
+	t.Setenv("NETBOX_HOST", "netbox_host")
+	t.Setenv("AUTH_TOKEN", "auth-token")
+	t.Setenv("RECONCILE_JITTER", "5s")
 	config.ResetForTesting()
-
-	os.Setenv("NETBOX_HOST", "netbox_host")
-	os.Setenv("AUTH_TOKEN", "auth-token")
-	os.Setenv("RECONCILE_JITTER", "5s")
 
 	maxJitter := config.GetOperatorConfig().ReconcileJitterDuration
 


### PR DESCRIPTION
This PR introduces optional scheduled reconciliation across the operator’s controllers, configured via a cron expression plus a jitter window to spread load over time.

Changes:

- Add RECONCILE_SCHEDULE (cron) and RECONCILE_JITTER (duration) to operator config parsing.
- Implement a shared scheduler helper and wire it into each controller’s reconcile defer-path when no other requeue is requested.
- Add kind overlay patch to set schedule/jitter env vars (and update kind kustomization).