### PR TITLE
Fix wrongfully assigned parentPrefix that is already exhausted.

### DIFF
--- a/kind/load-local-data-job/main.py
+++ b/kind/load-local-data-job/main.py
@@ -225,6 +225,7 @@ class Prefix:
 
 scopeId = nb.dcim.sites.get(name="MY_SITE").id
 
+# Note: 4.0.0.0/8 (4.x.y.z) prefixes are used by e2e tests that dynamically create the test data using Prefix custom resources.
 prefixes = [
     Prefix(
         prefix="2.0.0.0/16",

--- a/pkg/netbox/api/prefix_claim.go
+++ b/pkg/netbox/api/prefix_claim.go
@@ -173,12 +173,13 @@ func (c *NetboxCompositeClient) GetAvailablePrefixesByParentPrefixSelector(ctx c
 	for _, prefix := range list.Payload.Results {
 		if prefix.Prefix != nil {
 			errCandidate := c.isParentPrefixCandidate(ctx, prefixClaimSpec, *prefix.Prefix)
-			if err != nil {
+			if errCandidate != nil {
 				err = errors.Join(err, fmt.Errorf("prefix %s is not a valid parent prefix candidate, %w", *prefix.Prefix, errCandidate))
+			} else {
+				prefixes = append(prefixes, &models.Prefix{
+					Prefix: *prefix.Prefix,
+				})
 			}
-			prefixes = append(prefixes, &models.Prefix{
-				Prefix: *prefix.Prefix,
-			})
 		}
 	}
 

--- a/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/chainsaw-test.yaml
+++ b/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/chainsaw-test.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: prefixclaim-ipv4-parentprefixselector-sorting
+  annotations:
+    description: Tests that when a parent prefix is exhausted and a new matching parent prefix is created, the pending PrefixClaim is eventually assigned from the new parent prefix
+spec:
+  steps:
+    - name: Create parent prefix 4.0.2.0/24
+      try:
+        - apply:
+            file: netbox_v1_prefix_1.yaml
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sorting-parentprefix-1
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Apply PrefixClaim 1
+      try:
+        - apply:
+            file: netbox_v1_prefixclaim_1.yaml
+    - name: Check PrefixClaim 1 is ready
+      timeouts:
+        assert: 10s
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sorting-pxc1
+              status:
+                parentPrefix: 4.0.2.0/24
+                prefix: 4.0.2.0/25
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Apply PrefixClaim 2
+      try:
+        - apply:
+            file: netbox_v1_prefixclaim_2.yaml
+    - name: Check PrefixClaim 2 is ready
+      timeouts:
+        assert: 10s
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sorting-pxc2
+              status:
+                parentPrefix: 4.0.2.0/24
+                prefix: 4.0.2.128/25
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Apply PrefixClaim 3
+      try:
+        - apply:
+            file: netbox_v1_prefixclaim_3.yaml
+    - name: Check PrefixClaim 3 is not ready (parent prefix exhausted)
+      timeouts:
+        assert: 10s
+      try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Event
+              type: Warning
+              reason: PrefixCRNotCreated
+              source:
+                component: prefix-claim-controller
+              message: "Failed to assign prefix, prefix CR creation skipped: parent prefix exhausted, will restart the parent prefix selection process"
+              involvedObject:
+                apiVersion: netbox.dev/v1
+                kind: PrefixClaim
+                name: prefixclaim-ipv4-parentprefixselector-sorting-pxc3
+    - name: Create parent prefix 4.0.3.0/24
+      try:
+        - apply:
+            file: netbox_v1_prefix_2.yaml
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: Prefix
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sorting-parentprefix-2
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Check PrefixClaim 3 is now ready
+      timeouts:
+        assert: 30s
+      try:
+        - assert:
+            resource:
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
+                name: prefixclaim-ipv4-parentprefixselector-sorting-pxc3
+              status:
+                parentPrefix: 4.0.3.0/24
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+    - name: Cleanup events
+      description: Events cleanup required to fix issues with failing tests that assert the wrong Error resource
+      cleanup:
+        - script:
+            content: |-
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-sorting-pxc1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-sorting-pxc2 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=prefixclaim-ipv4-parentprefixselector-sorting-pxc3 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=parentprefix-1 -n $NAMESPACE
+              kubectl delete events --field-selector involvedObject.name=parentprefix-2 -n $NAMESPACE

--- a/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/chainsaw-test.yaml
+++ b/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/chainsaw-test.yaml
@@ -68,17 +68,13 @@ spec:
       try:
         - assert:
             resource:
-              apiVersion: v1
-              kind: Event
-              type: Warning
-              reason: PrefixCRNotCreated
-              source:
-                component: prefix-claim-controller
-              message: "Failed to assign prefix, prefix CR creation skipped: parent prefix exhausted, will restart the parent prefix selection process"
-              involvedObject:
-                apiVersion: netbox.dev/v1
-                kind: PrefixClaim
+              apiVersion: netbox.dev/v1
+              kind: PrefixClaim
+              metadata:
                 name: prefixclaim-ipv4-parentprefixselector-sorting-pxc3
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'False'
     - name: Create parent prefix 4.0.3.0/24
       try:
         - apply:

--- a/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefix_1.yaml
+++ b/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefix_1.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: netbox.dev/v1
+kind: Prefix
+metadata:
+  name: prefixclaim-ipv4-parentprefixselector-sorting-parentprefix-1
+spec:
+  prefix: "4.0.2.0/24"
+  site: "MY_SITE"
+  tenant: "MY_TENANT"
+  preserveInNetbox: false
+  customFields:
+    environment: "Production"
+    poolName: "test-parentprefixselector-sorting"

--- a/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefix_2.yaml
+++ b/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefix_2.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: netbox.dev/v1
+kind: Prefix
+metadata:
+  name: prefixclaim-ipv4-parentprefixselector-sorting-parentprefix-2
+spec:
+  prefix: "4.0.3.0/24"
+  site: "MY_SITE"
+  tenant: "MY_TENANT"
+  preserveInNetbox: false
+  customFields:
+    environment: "Production"
+    poolName: "test-parentprefixselector-sorting"

--- a/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefixclaim_1.yaml
+++ b/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefixclaim_1.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: netbox.dev/v1
+kind: PrefixClaim
+metadata:
+  name: prefixclaim-ipv4-parentprefixselector-sorting-pxc1
+spec:
+  tenant: "MY_TENANT"
+  site: "MY_SITE"
+  description: "some description"
+  comments: "your comments"
+  preserveInNetbox: false
+  prefixLength: "/25"
+  parentPrefixSelector:
+    tenant: "MY_TENANT"
+    site: "MY_SITE"
+    family: "IPv4"
+    environment: "Production"
+    poolName: "test-parentprefixselector-sorting"

--- a/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefixclaim_2.yaml
+++ b/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefixclaim_2.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: netbox.dev/v1
+kind: PrefixClaim
+metadata:
+  name: prefixclaim-ipv4-parentprefixselector-sorting-pxc2
+spec:
+  tenant: "MY_TENANT"
+  site: "MY_SITE"
+  description: "some description"
+  comments: "your comments"
+  preserveInNetbox: false
+  prefixLength: "/25"
+  parentPrefixSelector:
+    tenant: "MY_TENANT"
+    site: "MY_SITE"
+    family: "IPv4"
+    environment: "Production"
+    poolName: "test-parentprefixselector-sorting"

--- a/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefixclaim_3.yaml
+++ b/tests/e2e/prefix/ipv4/prefixclaim-ipv4-parentprefixselector-sorting/netbox_v1_prefixclaim_3.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: netbox.dev/v1
+kind: PrefixClaim
+metadata:
+  name: prefixclaim-ipv4-parentprefixselector-sorting-pxc3
+spec:
+  tenant: "MY_TENANT"
+  site: "MY_SITE"
+  description: "some description"
+  comments: "your comments"
+  preserveInNetbox: false
+  prefixLength: "/25"
+  parentPrefixSelector:
+    tenant: "MY_TENANT"
+    site: "MY_SITE"
+    family: "IPv4"
+    environment: "Production"
+    poolName: "test-parentprefixselector-sorting"


### PR DESCRIPTION
Add a test that reproduces a bug we've seen in production:

1. Creates 4.0.2.0/24 parent prefix → asserts Ready
2. Creates two /25 claims → both assigned from 4.0.2.0/24
3. Creates third /25 claim → gets exhaustion warning event
4. Creates 4.0.3.0/24 parent prefix → asserts Ready
5. Third claim doesn't become Ready, instead it will set the following condition:
```
  - lastTransitionTime: "2026-05-29T06:10:23Z"
    message: 'The parent prefix was selected successfully, parentPrefix is selected:
      4.0.2.0/24'
    observedGeneration: 1
    reason: ParentPrefixSelected
    status: "True"
    type: ParentPrefixSelected
```

Chainsaw test for the expected behaviour is added to this PR. When the code is fixed, the test should succeed.