### PR TITLE
feat: add token bucket algorithm configuration for NetBox API requests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,14 @@ type OperatorConfig struct {
 	// format: duration, needs to be parseable by time.ParseDuration, e.g. "30s", "30m"
 	// defaults to 1 hour
 	ReconcileJitterRaw string `mapstructure:"RECONCILE_JITTER"`
+	// Maximum sustained outbound requests per second to the NetBox API.
+	// A value <= 0 disables client-side throttling.
+	// defaults to 10
+	NetboxRateLimitQPS float64 `mapstructure:"NETBOX_RATE_LIMIT_QPS"`
+	// Maximum burst of outbound requests to the NetBox API allowed above the
+	// sustained QPS. Only takes effect when NETBOX_RATE_LIMIT_QPS > 0.
+	// defaults to 20
+	NetboxRateLimitBurst int `mapstructure:"NETBOX_RATE_LIMIT_BURST"`
 
 	// Parsed fields (not from config file/env)
 	ReconcileSchedule       cron.Schedule
@@ -71,6 +79,8 @@ func (c *OperatorConfig) setDefaults() {
 	c.viper.SetDefault("RECONCILE_JITTER", "")
 	c.viper.SetDefault("RECONCILE_SCHEDULE", "")
 
+	c.viper.SetDefault("NETBOX_RATE_LIMIT_QPS", 10)
+	c.viper.SetDefault("NETBOX_RATE_LIMIT_BURST", 20)
 }
 
 func (c *OperatorConfig) LoadCaCert() (cert []byte, err error) {

--- a/pkg/netbox/api/client.go
+++ b/pkg/netbox/api/client.go
@@ -29,6 +29,7 @@ import (
 	v3client "github.com/netbox-community/go-netbox/v3/netbox/client"
 	"github.com/netbox-community/netbox-operator/pkg/config"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 
 	"github.com/netbox-community/go-netbox/v3/netbox/client/extras"
 	"github.com/netbox-community/netbox-operator/pkg/netbox/interfaces"
@@ -62,9 +63,19 @@ func (c *NetboxCompositeClient) VerifyNetboxConfiguration() error {
 
 type InstrumentedRoundTripper struct {
 	Transport http.RoundTripper
+	// Limiter applies a token-bucket rate limit to outbound NetBox requests.
+	// When nil, no throttling is performed.
+	Limiter *rate.Limiter
 }
 
 func (irt *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if irt.Limiter != nil {
+		// Block until the bucket has a token (or the request context is cancelled).
+		if err := irt.Limiter.Wait(req.Context()); err != nil {
+			return nil, err
+		}
+	}
+
 	resp, err := irt.Transport.RoundTrip(req)
 	if err != nil {
 		return nil, err
@@ -72,6 +83,18 @@ func (irt *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 
 	metrics.RequestResult.Increment(context.TODO(), strconv.Itoa(resp.StatusCode), req.Method, req.Host)
 	return resp, nil
+}
+
+// newNetboxLimiter builds a token-bucket limiter from the operator config,
+// or returns nil when throttling is disabled (QPS <= 0).
+func newNetboxLimiter(qps float64, burst int) *rate.Limiter {
+	if qps <= 0 {
+		return nil
+	}
+	if burst < 1 {
+		burst = 1
+	}
+	return rate.NewLimiter(rate.Limit(qps), burst)
 }
 
 func GetNetboxClient() (*NetboxClientV3, error) {
@@ -101,13 +124,19 @@ func GetNetboxClient() (*NetboxClientV3, error) {
 		tlsConfig.RootCAs = caRootPool
 	}
 
-	httpClient := &http.Client{
-		Transport: &InstrumentedRoundTripper{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
+	var baseTransport http.RoundTripper = &InstrumentedRoundTripper{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
 		},
-		Timeout: time.Second * time.Duration(RequestTimeout),
+		Limiter: newNetboxLimiter(
+			config.GetOperatorConfig().NetboxRateLimitQPS,
+			config.GetOperatorConfig().NetboxRateLimitBurst,
+		),
+	}
+
+	httpClient := &http.Client{
+		Transport: baseTransport,
+		Timeout:   time.Second * time.Duration(RequestTimeout),
 	}
 
 	transport := httptransport.NewWithClient(config.GetOperatorConfig().NetboxHost, v3client.DefaultBasePath, desiredRuntimeClientSchemes, httpClient)

--- a/pkg/netbox/api/clientv4.go
+++ b/pkg/netbox/api/clientv4.go
@@ -56,13 +56,19 @@ func GetNetboxClientV4() (*NetboxClientV4, error) {
 		tlsConfig.RootCAs = caRootPool
 	}
 
-	httpClient := &http.Client{
-		Transport: &InstrumentedRoundTripper{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
+	var baseTransport http.RoundTripper = &InstrumentedRoundTripper{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
 		},
-		Timeout: time.Second * time.Duration(RequestTimeout),
+		Limiter: newNetboxLimiter(
+			config.GetOperatorConfig().NetboxRateLimitQPS,
+			config.GetOperatorConfig().NetboxRateLimitBurst,
+		),
+	}
+
+	httpClient := &http.Client{
+		Transport: baseTransport,
+		Timeout:   time.Second * time.Duration(RequestTimeout),
 	}
 
 	desiredRuntimeClientScheme := "http"


### PR DESCRIPTION
Adds an optional client-side throttle in front of the NetBox HTTP client using golang.org/x/time/rate. Requests wait for a token before being sent, so the operator cannot bursts the NetBox API when many reconciles fire at once.

Configurable via two env vars (defaults: 10 QPS, burst 20):
- NETBOX_RATE_LIMIT_QPS
- NETBOX_RATE_LIMIT_BURST

Setting NETBOX_RATE_LIMIT_QPS=0 disables the limiter (unchanged behaviour).

Implemented as a small addition to the existing InstrumentedRoundTripper, so it composes cleanly with the current metrics middleware and applies to both the v3 and v4 clients.

Note: the v3 and v4 clients currently use independent limiters, so the effective rate is ~2× the configured value.
