### PR TITLE
Inherit VRF from parent prefix when reserving IP addresses

### DIFF
--- a/internal/controller/ipaddress_controller.go
+++ b/internal/controller/ipaddress_controller.go
@@ -48,6 +48,7 @@ import (
 
 const IpAddressFinalizerName = "ipaddress.netbox.dev/finalizer"
 const IPManagedCustomFieldsAnnotationName = "ipaddress.netbox.dev/managed-custom-fields"
+const IPVrfIdAnnotationName = "ipaddress.netbox.dev/vrf-id"
 
 // IpAddressReconciler reconciles a IpAddress object
 type IpAddressReconciler struct {
@@ -182,6 +183,14 @@ func (r *IpAddressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	ipAddressModel, err := generateNetboxIpAddressModelFromIpAddressSpec(&o.Spec, req, annotations[IPManagedCustomFieldsAnnotationName])
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if vrfIdStr, ok := annotations[IPVrfIdAnnotationName]; ok && vrfIdStr != "" {
+		vrfId, err := strconv.ParseInt(vrfIdStr, 10, 64)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to parse %s annotation: %w", IPVrfIdAnnotationName, err)
+		}
+		ipAddressModel.VrfId = &vrfId
 	}
 
 	netboxIpAddressModel, statusUpToDate, err := r.NetboxClient.ReserveOrUpdateIpAddress(ctx, ipAddressModel, o)

--- a/internal/controller/ipaddressclaim_controller.go
+++ b/internal/controller/ipaddressclaim_controller.go
@@ -158,7 +158,7 @@ func (r *IpAddressClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 
 		// 6.a create the IPAddress object
-		ipAddressResource := generateIpAddressFromIpAddressClaim(o, ipAddressModel.IpAddress, logger)
+		ipAddressResource := generateIpAddressFromIpAddressClaim(o, ipAddressModel.IpAddress, ipAddressModel.VrfId, logger)
 		if err := controllerutil.SetControllerReference(o, ipAddressResource, r.Scheme); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set controller reference: %w", err)
 		}

--- a/internal/controller/ipaddressclaim_helpers.go
+++ b/internal/controller/ipaddressclaim_helpers.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"crypto/sha1"
 	"fmt"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	netboxv1 "github.com/netbox-community/netbox-operator/api/v1"
@@ -26,11 +27,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func generateIpAddressFromIpAddressClaim(claim *netboxv1.IpAddressClaim, ip string, logger logr.Logger) *netboxv1.IpAddress {
+func generateIpAddressFromIpAddressClaim(claim *netboxv1.IpAddressClaim, ip string, vrfId *int64, logger logr.Logger) *netboxv1.IpAddress {
+	var annotations map[string]string
+	if vrfId != nil {
+		annotations = map[string]string{
+			IPVrfIdAnnotationName: strconv.FormatInt(*vrfId, 10),
+		}
+	}
+
 	ipAddressResource := &netboxv1.IpAddress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      claim.Name,
-			Namespace: claim.Namespace,
+			Name:        claim.Name,
+			Namespace:   claim.Namespace,
+			Annotations: annotations,
 		},
 		Spec: generateIpAddressSpec(claim, ip, logger),
 	}

--- a/pkg/netbox/api/ip_address.go
+++ b/pkg/netbox/api/ip_address.go
@@ -41,6 +41,7 @@ func (c *NetboxCompositeClient) ReserveOrUpdateIpAddress(ctx context.Context, ip
 		Address:     &ipAddress.IpAddress,
 		Description: TruncateDescription(""),
 		Status:      "active",
+		Vrf:         ipAddress.VrfId,
 	}
 
 	if ipAddress.Metadata != nil {
@@ -64,6 +65,13 @@ func (c *NetboxCompositeClient) ReserveOrUpdateIpAddress(ctx context.Context, ip
 	}
 
 	ipToUpdate := responseIpAddress.Payload.Results[0]
+
+	// preserve the existing NetBox VRF on update when the caller didn't resolve
+	// a fresh one (e.g. IpAddress reconciled outside the IpAddressClaim flow),
+	// since this is a full PUT and would otherwise null out VRF
+	if desiredIPAddress.Vrf == nil && ipToUpdate.Vrf != nil {
+		desiredIPAddress.Vrf = &ipToUpdate.Vrf.ID
+	}
 
 	if ipToUpdate.LastUpdated.IsZero() {
 		return nil, false, fmt.Errorf("last updated field is not set in Netbox for ip address %s", ipAddress.IpAddress)

--- a/pkg/netbox/api/ip_address_claim.go
+++ b/pkg/netbox/api/ip_address_claim.go
@@ -66,8 +66,14 @@ func (c *NetboxCompositeClient) RestoreExistingIpByHash(hash string) (*models.IP
 		return nil, errors.New("ipaddress in netbox is nil")
 	}
 
+	var vrfId *int64
+	if res.Vrf != nil {
+		vrfId = &res.Vrf.ID
+	}
+
 	return &models.IPAddress{
 		IpAddress: *res.Address,
+		VrfId:     vrfId,
 	}, nil
 }
 
@@ -98,13 +104,21 @@ func (c *NetboxCompositeClient) GetAvailableIpAddressByClaim(ctx context.Context
 		return nil, err
 	}
 
-	ipAddress, err := SetIpAddressMask(responseAvailableIPs.Payload[0].Address, responseAvailableIPs.Payload[0].Family)
+	availableIp := responseAvailableIPs.Payload[0]
+
+	ipAddress, err := SetIpAddressMask(availableIp.Address, availableIp.Family)
 	if err != nil {
 		return nil, err
 	}
 
+	var vrfId *int64
+	if availableIp.Vrf != nil {
+		vrfId = &availableIp.Vrf.ID
+	}
+
 	return &models.IPAddress{
 		IpAddress: ipAddress,
+		VrfId:     vrfId,
 	}, nil
 }
 

--- a/pkg/netbox/api/ip_address_claim_test.go
+++ b/pkg/netbox/api/ip_address_claim_test.go
@@ -131,12 +131,14 @@ func TestIPAddressClaim(t *testing.T) {
 			Execute().
 			Return(&v4client.PaginatedPrefixList{Results: []v4client.Prefix{expectedPrefix}}, &http.Response{StatusCode: 200, Body: http.NoBody}, nil)
 
+		vrfId := int64(7)
 		inputIps := ipam.NewIpamPrefixesAvailableIpsListParams().WithID(int64(parentPrefixIdV4))
 		outputIps := &ipam.IpamPrefixesAvailableIpsListOK{
 			Payload: []*netboxModels.AvailableIP{
 				{
 					Address: ipAddressV4_2,
 					Family:  int64(IPv4Family),
+					Vrf:     &netboxModels.NestedVRF{ID: vrfId},
 				},
 			}}
 
@@ -169,6 +171,8 @@ func TestIPAddressClaim(t *testing.T) {
 		AssertNil(t, err)
 		// assert nil output
 		assert.Equal(t, singleIpAddressV4_2, actual.IpAddress)
+		// assert vrf inherited from parent prefix's available-ip response
+		assert.Equal(t, &vrfId, actual.VrfId)
 	})
 
 	t.Run("Fetch first available IP address by claim (IPv6).", func(t *testing.T) {
@@ -232,6 +236,8 @@ func TestIPAddressClaim(t *testing.T) {
 		AssertNil(t, err)
 		// assert nil output
 		assert.Equal(t, singleIpAddressV6, actual.IpAddress)
+		// assert no vrf when parent prefix is in the global vrf
+		assert.Nil(t, actual.VrfId)
 	})
 
 	t.Run("Fetch first available IP address by claim (invalid IP family).", func(t *testing.T) {
@@ -379,6 +385,7 @@ func TestIPAddressClaim(t *testing.T) {
 	t.Run("Reclaim IP Address", func(t *testing.T) {
 
 		ipAddressRestore := "10.111.111.111/32"
+		restoreVrfId := int64(9)
 
 		input := "403f19fcb98beaf5a25018536ed5275714a132ff"
 		output := &ipam.IpamIPAddressesListOK{
@@ -389,6 +396,7 @@ func TestIPAddressClaim(t *testing.T) {
 				Results: []*netboxModels.IPAddress{
 					{
 						Address: &ipAddressRestore,
+						Vrf:     &netboxModels.NestedVRF{ID: restoreVrfId},
 					},
 				},
 			},
@@ -412,6 +420,7 @@ func TestIPAddressClaim(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, ipAddressRestore, actual.IpAddress)
+		assert.Equal(t, &restoreVrfId, actual.VrfId)
 	})
 }
 

--- a/pkg/netbox/api/ip_address_test.go
+++ b/pkg/netbox/api/ip_address_test.go
@@ -396,6 +396,80 @@ func TestIPAddress(t *testing.T) {
 		assert.Equal(t, expectedIPAddress().LastUpdated, result.LastUpdated)
 	})
 
+	t.Run("create sets vrf from resolved VrfId", func(t *testing.T) {
+		vrfId := int64(11)
+
+		inputList := ipam.NewIpamIPAddressesListParams().WithAddress(&ipAddress)
+		outputList := &ipam.IpamIPAddressesListOK{
+			Payload: &ipam.IpamIPAddressesListOKBody{
+				Results: []*netboxModels.IPAddress{},
+			},
+		}
+
+		expectedWritable := &netboxModels.WritableIPAddress{
+			Address:     &ipAddress,
+			Description: TruncateDescription(""),
+			Status:      "active",
+			Vrf:         &vrfId,
+		}
+		inputCreate := ipam.NewIpamIPAddressesCreateParams().WithDefaults().WithData(expectedWritable)
+
+		mockIPAddress.EXPECT().IpamIPAddressesList(inputList, nil).Return(outputList, nil)
+		mockIPAddress.EXPECT().IpamIPAddressesCreate(inputCreate, nil).Return(&ipam.IpamIPAddressesCreateCreated{Payload: expectedIPAddress()}, nil)
+
+		clientV3 := &NetboxClientV3{Ipam: mockIPAddress}
+		compositeClient := &NetboxCompositeClient{clientV3: clientV3}
+
+		result, isUpToDate, err := compositeClient.ReserveOrUpdateIpAddress(context.TODO(), &models.IPAddress{
+			IpAddress: ipAddress,
+			VrfId:     &vrfId,
+		}, &netboxv1.IpAddress{})
+
+		AssertNil(t, err)
+		assert.NotNil(t, result)
+		assert.False(t, isUpToDate)
+	})
+
+	t.Run("update preserves existing vrf when VrfId is not resolved", func(t *testing.T) {
+		existingVrfId := int64(12)
+
+		inputList := ipam.NewIpamIPAddressesListParams().WithAddress(&ipAddress)
+		outputList := &ipam.IpamIPAddressesListOK{
+			Payload: &ipam.IpamIPAddressesListOKBody{
+				Results: []*netboxModels.IPAddress{
+					{
+						ID:          expectedIPAddress().ID,
+						Address:     expectedIPAddress().Address,
+						LastUpdated: expectedIPAddress().LastUpdated,
+						Vrf:         &netboxModels.NestedVRF{ID: existingVrfId},
+					},
+				},
+			},
+		}
+
+		expectedWritable := &netboxModels.WritableIPAddress{
+			Address:     &ipAddress,
+			Description: TruncateDescription(""),
+			Status:      "active",
+			Vrf:         &existingVrfId,
+		}
+		inputUpdate := ipam.NewIpamIPAddressesUpdateParams().WithDefaults().WithData(expectedWritable).WithID(expectedIPAddress().ID)
+
+		mockIPAddress.EXPECT().IpamIPAddressesList(inputList, nil).Return(outputList, nil)
+		mockIPAddress.EXPECT().IpamIPAddressesUpdate(inputUpdate, nil).Return(&ipam.IpamIPAddressesUpdateOK{Payload: expectedIPAddress()}, nil)
+
+		clientV3 := &NetboxClientV3{Ipam: mockIPAddress}
+		compositeClient := &NetboxCompositeClient{clientV3: clientV3}
+
+		result, isUpToDate, err := compositeClient.ReserveOrUpdateIpAddress(context.TODO(), &models.IPAddress{
+			IpAddress: ipAddress,
+		}, &netboxv1.IpAddress{})
+
+		AssertNil(t, err)
+		assert.NotNil(t, result)
+		assert.False(t, isUpToDate)
+	})
+
 	t.Run("skip update when LastUpdated matches and Condition is Ready and Generation matches (no hash)", func(t *testing.T) {
 		inputList := ipam.NewIpamIPAddressesListParams().WithAddress(&ipAddress)
 		outputList := &ipam.IpamIPAddressesListOK{

--- a/pkg/netbox/models/ipam.go
+++ b/pkg/netbox/models/ipam.go
@@ -39,6 +39,7 @@ type NetboxMetadata struct {
 
 type IPAddress struct {
 	IpAddress string          `json:"ipAddress,omitempty"`
+	VrfId     *int64          `json:"vrfId,omitempty"`
 	Metadata  *NetboxMetadata `json:"metadata,omitempty"`
 }
 


### PR DESCRIPTION
IpAddressClaim previously created IP addresses with no VRF set, so they didn't show up nested under a parent prefix that has a non-global VRF in NetBox. NetBox's available-ips response already carries the prefix's VRF; thread it through into the WritableIPAddress sent on create, and preserve the existing VRF on update since it's a full PUT.